### PR TITLE
Validate incoming data using the JSON table schema of the resource

### DIFF
--- a/datapackage_pipelines/lib/concat.py
+++ b/datapackage_pipelines/lib/concat.py
@@ -49,7 +49,7 @@ def process_resources(_res_iter):
             values = [(column_mapping[k], v) for (k, v)
                       in row.items()
                       if k in column_mapping]
-            assert len(values)>0
+            assert len(values) > 0
             processed.update(dict(values))
             yield processed
 

--- a/datapackage_pipelines/lib/downloader.py
+++ b/datapackage_pipelines/lib/downloader.py
@@ -10,7 +10,6 @@ from jsontableschema.model import SchemaModel
 from datapackage_pipelines.wrapper import ingest, spew
 
 
-
 def _reader(opener, _url):
     yield None
     filename = os.path.basename(_url)

--- a/datapackage_pipelines/lib/dump.py
+++ b/datapackage_pipelines/lib/dump.py
@@ -16,7 +16,7 @@ params, datapackage, res_iter = ingest()
 out_filename = open(params['out-file'], 'wb')
 out_file = zipfile.ZipFile(out_filename, 'w')
 
-out_file.writestr('datapackage.json', json.dumps(datapackage))
+out_file.writestr('datapackage.json', json.dumps(datapackage, ensure_ascii=True))
 
 
 def transform_value(value, _):
@@ -33,13 +33,13 @@ def transform_row(row, fields):
 def rows_processor(_rows, _csv_file, _zip_file, _writer, _fields, _schema):
     for row in _rows:
         transformed_row = transform_row(row, _fields)
-        _writer.writerow(transformed_row)
         for k, v in transformed_row.items():
             try:
                 _schema.cast(k, v)
             except InvalidCastError:
                 logging.error('Bad value %r for field %s', v, k)
                 raise
+        _writer.writerow(transformed_row)
         yield row
     _zip_file.writestr(_rows.spec['path'], _csv_file.getvalue())
 

--- a/datapackage_pipelines/manager/specs.py
+++ b/datapackage_pipelines/manager/specs.py
@@ -15,8 +15,8 @@ def find_specs(root_dir='.'):
         if SPEC_FILENAME in filenames:
             abspath = os.path.abspath(dirpath)
             fullpath = os.path.join(abspath, SPEC_FILENAME)
-            with open(fullpath) as spec_file:
-                spec = yaml.load(spec_file)
+            with open(fullpath, encoding='utf8') as spec_file:
+                spec = yaml.load(spec_file.read())
                 for pipeline_id, pipeline_details in spec.items():
                     pipeline_id = os.path.join(dirpath, pipeline_id)
                     yield abspath, pipeline_id, pipeline_details


### PR DESCRIPTION
This pull request fixes #2 .

Added validation of the data via the JTS of the resource.
Note that since data between processors is moved as json objects, this merely makes sure that the _Python_ data types are correct.