### PR TITLE
Update the resource metadata before zipping datapackage.

### DIFF
--- a/datapackage_pipelines/lib/dump.py
+++ b/datapackage_pipelines/lib/dump.py
@@ -18,9 +18,8 @@ out_file = zipfile.ZipFile(out_filename, 'w')
 
 for resource in datapackage['resources']:
     resource['encoding'] = 'utf-8'
-    extension = os.path.splitext(resource['path'])[1].lstrip('.')
-    pattern = '{}$'.format(extension)
-    resource['path'] = re.sub(pattern, 'csv', resource['path'])
+    basename, extension = os.path.splitext(resource['path'])
+    resource['path'] = basename + '.csv'
 
 out_file.writestr('datapackage.json',
                   json.dumps(datapackage, ensure_ascii=True))

--- a/datapackage_pipelines/lib/dump.py
+++ b/datapackage_pipelines/lib/dump.py
@@ -15,6 +15,11 @@ params, datapackage, res_iter = ingest()
 out_filename = open(params['out-file'], 'wb')
 out_file = zipfile.ZipFile(out_filename, 'w')
 
+for resource in datapackage['resources']:
+    resource['encoding'] = 'utf-8'
+    _, extension = os.path.splitext(resource['path'])
+    resource['path'] = resource['path'].replace(extension, '.csv')
+
 out_file.writestr('datapackage.json',
                   json.dumps(datapackage, ensure_ascii=True))
 

--- a/datapackage_pipelines/lib/dump.py
+++ b/datapackage_pipelines/lib/dump.py
@@ -2,6 +2,7 @@ import os
 import zipfile
 import csv
 import json
+import re
 import tempfile
 import logging
 
@@ -17,8 +18,9 @@ out_file = zipfile.ZipFile(out_filename, 'w')
 
 for resource in datapackage['resources']:
     resource['encoding'] = 'utf-8'
-    _, extension = os.path.splitext(resource['path'])
-    resource['path'] = resource['path'].replace(extension, '.csv')
+    extension = os.path.splitext(resource['path'])[1].lstrip('.')
+    pattern = '{}$'.format(extension)
+    resource['path'] = re.sub(pattern, 'csv', resource['path'])
 
 out_file.writestr('datapackage.json',
                   json.dumps(datapackage, ensure_ascii=True))


### PR DESCRIPTION
@akariv This pull request fixes wrong encoding guess upon Babbage fiscal uploads and wrong filenames in the zip-dumps. I've haven't added tests to cover the proposed changes. I'm not sure if this is the right place to implement the changes.

Changes proposed in this pull request:

- set encoding explicitly to utf-8
- ensure file extension is .csv