### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     description='{{ DESCRIPTION }}',
     author='Open Knowledge Foundation',
     author_email='info@okfn.org',
-    url='https://github.com/frictionlessdat/datapackage-pipelines',
+    url='https://github.com/frictionlessdata/datapackage-pipelines',
     license='MIT',
     keywords=[
         'data',


### PR DESCRIPTION
fix typo in org-name path-component of setup url arg

This pull request fixes: no issue created for tiny typo.

* [ ] I've added tests to cover the proposed changes

No, but hoping I can get a pass for what is almost  only a documentation typo. 

Changes proposed in this pull request:

-Make link to the repo from PyPI work! :)

Thanks for sharing your code!!