### PR TITLE
worldbank-co2-emissions is in ./samples/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ $ docker run -v `pwd`:/pipelines:rw \
 <available-pipelines>
 
 $ docker run -v `pwd`:/pipelines:rw \
-       frictionlessdata/datapackage-pipelines run ./worldbank-co2-emissions
+       frictionlessdata/datapackage-pipelines run ./samples/worldbank-co2-emissions
 <execution-logs>
 ```
 


### PR DESCRIPTION
This pull request fixes #24.

* [ ] I've added tests to cover the proposed changes

Changes proposed in this pull request:

- Fix README.md so that quick Docker example references spec in ./samples/ directory