### PR TITLE
ensure closing files while validating specs (prevents ResourceWarnings)

### DIFF
--- a/datapackage_pipelines/manager/specs.py
+++ b/datapackage_pipelines/manager/specs.py
@@ -141,7 +141,8 @@ def calculate_hash(dependencies, pipeline, all_pipeline_ids):
     for step in pipeline:
         m = hashlib.md5()
         m.update(cache_hash.encode('ascii'))
-        m.update(open(step['run'], 'rb').read())
+        with open(step['run'], 'rb') as f:
+            m.update(f.read())
         m.update(json.dumps(step, ensure_ascii=True, sort_keys=True)
                  .encode('ascii'))
         cache_hash = m.hexdigest()


### PR DESCRIPTION
I encountered a lot of warnings about unclosed files when opening and validating a pipeline.

This simple change fixes it - ensuring files are closed

these are the warnings I got (when running unit tests on a different project):
```
/home/ori/datapackage-pipelines/datapackage_pipelines/manager/specs.py:144: ResourceWarning: unclosed file <_io.BufferedReader name='/home/ori/datapackage-pipelines/datapackage_pipelines/manager/../lib/concatenate.py'>
  m.update(open(step['run'], 'rb').read())
/home/ori/datapackage-pipelines/datapackage_pipelines/manager/specs.py:144: ResourceWarning: unclosed file <_io.BufferedReader name='/home/ori/datapackage-pipelines/datapackage_pipelines/manager/../lib/set_types.py'>
  m.update(open(step['run'], 'rb').read())
/home/ori/datapackage-pipelines/datapackage_pipelines/manager/specs.py:144: ResourceWarning: unclosed file <_io.BufferedReader name='/home/ori/datapackage-pipelines/datapackage_pipelines/manager/../lib/join.py'>
  m.update(open(step['run'], 'rb').read())
/home/ori/datapackage-pipelines/datapackage_pipelines/manager/specs.py:144: ResourceWarning: unclosed file <_io.BufferedReader name='/home/ori/datapackage-pipelines/datapackage_pipelines/manager/../lib/dump/to_path.py'>
  m.update(open(step['run'], 'rb').read())
/home/ori/datapackage-pipelines/datapackage_pipelines/manager/specs.py:144: ResourceWarning: unclosed file <_io.BufferedReader name='/home/ori/datapackage-pipelines/datapackage_pipelines/manager/../lib/dump/to_sql.py'>
  m.update(open(step['run'], 'rb').read())
```