### PR TITLE
Update references of Python 3.5 --> 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ INFO :Main:SUCCESS: ./worldbank-co2-emissions
 					{'dataset-name': 'co2-emissions', 'total_row_count': 264}
 ```
 
-(Requirements: _Python 3.5_ or higher)
+(Requirements: _Python 3.6_ or higher)
 
 Alternatively, you could use our docker image:
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     entry_points={


### PR DESCRIPTION
Recent changes (c62ea0afdce35484126948c5825fe1cfe7e96820) mean Python 3.6 is required.

Changes proposed in this pull request:

- Updated README
- Updated setup.py