### PR TITLE
Allow Generators to yield pipelines without schedules

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,23 +892,24 @@ class Generator(GeneratorBase):
         pipeline_id = dataset_name = slugify(source['name'])
         host = source['ckan-instance']
         action = source['data-kind']
-        
-        if action == 'package-list':            
-          schedule = SCHEDULE_MONTHLY
-          yield pipeline_id, schedule, steps(*[
-                  ('ckan.scraper',
-                   {
-                       'ckan-instance': host
-                   }),
-                  ('metadata', {
-                      'name': dataset_name  
-                  }),
-                  ('dump_to_zip',
-                   {
-                       'out-file': 'ckan-datapackage.zip'
-                   })
-                  ]
-          )
+
+        if action == 'package-list':
+            schedule = SCHEDULE_MONTHLY
+            pipeline_steps = steps(*[
+                ('ckan.scraper', {
+                   'ckan-instance': host
+                }),
+                ('metadata', {
+                  'name': dataset_name
+                }),
+                ('dump.to_zip', {
+                   'out-file': 'ckan-datapackage.zip'
+                })])
+        pipeline_details = {
+            'pipeline': pipeline_steps,
+            'schedule': {'crontab': schedule}
+        }
+        yield pipeline_id, pipeline_details
 ```
 
 In this case, if we store a `ckan.source-spec.yaml` file looking like this:

--- a/README.md
+++ b/README.md
@@ -905,11 +905,11 @@ class Generator(GeneratorBase):
                 ('dump.to_zip', {
                    'out-file': 'ckan-datapackage.zip'
                 })])
-        pipeline_details = {
-            'pipeline': pipeline_steps,
-            'schedule': {'crontab': schedule}
-        }
-        yield pipeline_id, pipeline_details
+            pipeline_details = {
+                'pipeline': pipeline_steps,
+                'schedule': {'crontab': schedule}
+            }
+            yield pipeline_id, pipeline_details
 ```
 
 In this case, if we store a `ckan.source-spec.yaml` file looking like this:

--- a/datapackage_pipelines/generators/schedules.py
+++ b/datapackage_pipelines/generators/schedules.py
@@ -1,3 +1,4 @@
+SCHEDULE_NONE = None
 SCHEDULE_HOURLY = '0 * * * *'
 SCHEDULE_DAILY = '0 0 * * *'
 SCHEDULE_WEEKLY = '0 0 * * 0'

--- a/datapackage_pipelines/specs/parsers/source_spec_pipeline.py
+++ b/datapackage_pipelines/specs/parsers/source_spec_pipeline.py
@@ -37,9 +37,12 @@ class SourceSpecPipelineParser(BaseParser):
                     spec = generator.internal_generate(source_spec)
                     for pipeline_id, schedule, steps in spec:
                         pipeline_details = {
-                            'schedule': {'crontab': schedule},
                             'pipeline': steps
                         }
+                        if schedule is not None:
+                            pipeline_details['schedule'] = {
+                                'crontab': schedule
+                            }
                         pipeline_id = os.path.join(dirpath, pipeline_id)
                         yield PipelineSpec(path=dirpath,
                                            pipeline_id=pipeline_id,

--- a/datapackage_pipelines/specs/parsers/source_spec_pipeline.py
+++ b/datapackage_pipelines/specs/parsers/source_spec_pipeline.py
@@ -35,14 +35,7 @@ class SourceSpecPipelineParser(BaseParser):
                 source_spec = yaml.load(spec_file.read())
                 if generator.internal_validate(source_spec):
                     spec = generator.internal_generate(source_spec)
-                    for pipeline_id, schedule, steps in spec:
-                        pipeline_details = {
-                            'pipeline': steps
-                        }
-                        if schedule is not None:
-                            pipeline_details['schedule'] = {
-                                'crontab': schedule
-                            }
+                    for pipeline_id, pipeline_details in spec:
                         pipeline_id = os.path.join(dirpath, pipeline_id)
                         yield PipelineSpec(path=dirpath,
                                            pipeline_id=pipeline_id,


### PR DESCRIPTION
Schedules are optional in pipelines. This PR allows `None` to be passed as the schedule when yielding pipelines from a Generator class.

Changes proposed in this pull request:

- The source spec parser checks if there's a schedule before adding it to the pipeline details
- A `SCHEDULE_NONE` static property to provide an explicit name when constructing generators
