### PR TITLE
Gitignore .dpp.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,4 +82,4 @@ target/
 datapackage-pipelines.iml
 celerybeat-schedule
 
-.dppdb
+.dpp.db


### PR DESCRIPTION
I think this was simply a typo.

Changes proposed in this pull request:

- Just adds the dot so .dpp.db is ignored by git