### PR TITLE
Move `test_single_fixture()` into `ProcessorFixtureTestBase` class

### DIFF
--- a/datapackage_pipelines/utilities/lib_test_helpers.py
+++ b/datapackage_pipelines/utilities/lib_test_helpers.py
@@ -21,7 +21,7 @@ class ProcessorFixtureTestsBase(object):
 
                 def inner(processor_, params_, data_in_, dp_out_, data_out_):
                     def inner2():
-                        return test_single_fixture(processor_, params_, data_in_, dp_out_, data_out_,
+                        return self.test_single_fixture(processor_, params_, data_in_, dp_out_, data_out_,
                                                    self._get_procesor_env())
                     return inner2
                 yield filename, inner(processor, params, data_in, dp_out, data_out)
@@ -52,29 +52,29 @@ class ProcessorFixtureTestsBase(object):
         data_in = (dp_in + '\n\n' + data_in).encode('utf8')
         return data_in, data_out, dp_out, params, processor_file
 
-
-def test_single_fixture(processor, parameters, data_in, dp_out, data_out, env):
-    """Test a single processor with the given fixture parameters"""
-    process = subprocess.run([sys.executable, processor, '1', parameters, 'False', ''],
-                             input=data_in, stdout=subprocess.PIPE, env=env)
-    output = process.stdout.decode('utf8')
-    (actual_dp, *actual_data) = output.split('\n\n', 1)
-    assert actual_dp == dp_out, "unexpected value for output datapackage: {}".format(actual_dp)
-    if len(actual_data) > 0:
-        actual_data = actual_data[0]
-        actual_data = actual_data.split('\n')
-        expected_data = data_out.split('\n')
-        assert len(actual_data) == len(expected_data), \
-            "unexpected number of output lines: {}, actual_data = {}".format(len(actual_data), actual_data)
-        for line_num, (actual, expected) in enumerate(zip(actual_data, expected_data)):
-            line_msg = "output line {}".format(line_num)
-            if len(actual) == 0:
-                assert len(expected) == 0, \
-                    "{}: did not get any data (but expected some)".format(line_msg)
-            else:
-                rj_actual = rejsonize(actual)
-                assert rj_actual == rejsonize(expected), \
-                    "{}: unexpected data: {}".format(line_msg, rj_actual)
+    @staticmethod
+    def test_single_fixture(processor, parameters, data_in, dp_out, data_out, env):
+        """Test a single processor with the given fixture parameters"""
+        process = subprocess.run([sys.executable, processor, '1', parameters, 'False', ''],
+                                 input=data_in, stdout=subprocess.PIPE, env=env)
+        output = process.stdout.decode('utf8')
+        (actual_dp, *actual_data) = output.split('\n\n', 1)
+        assert actual_dp == dp_out, "unexpected value for output datapackage: {}".format(actual_dp)
+        if len(actual_data) > 0:
+            actual_data = actual_data[0]
+            actual_data = actual_data.split('\n')
+            expected_data = data_out.split('\n')
+            assert len(actual_data) == len(expected_data), \
+                "unexpected number of output lines: {}, actual_data = {}".format(len(actual_data), actual_data)
+            for line_num, (actual, expected) in enumerate(zip(actual_data, expected_data)):
+                line_msg = "output line {}".format(line_num)
+                if len(actual) == 0:
+                    assert len(expected) == 0, \
+                        "{}: did not get any data (but expected some)".format(line_msg)
+                else:
+                    rj_actual = rejsonize(actual)
+                    assert rj_actual == rejsonize(expected), \
+                        "{}: unexpected data: {}".format(line_msg, rj_actual)
 
 
 def rejsonize(s):

--- a/datapackage_pipelines/utilities/lib_test_helpers.py
+++ b/datapackage_pipelines/utilities/lib_test_helpers.py
@@ -1,7 +1,9 @@
 """
-This module contains code that can be used to run automated tests of datapackage pipelines processors
+This module contains code that can be used to run automated tests of
+datapackage pipelines processors
 
-It is used internally to test the standard library processors but supports external use as well.
+It is used internally to test the standard library processors but supports
+external use as well.
 """
 import os
 import subprocess
@@ -17,26 +19,35 @@ class ProcessorFixtureTestsBase(object):
     def get_tests(self):
         for dirpath, _, filenames in os.walk(self._fixtures_path):
             for filename in filenames:
-                data_in, data_out, dp_out, params, processor = self._load_fixture(dirpath, filename)
+                data_in, data_out, dp_out, params, processor = \
+                    self._load_fixture(dirpath, filename)
 
                 def inner(processor_, params_, data_in_, dp_out_, data_out_):
                     def inner2():
-                        return self.test_single_fixture(processor_, params_, data_in_, dp_out_, data_out_,
-                                                   self._get_procesor_env())
+                        return self.test_single_fixture(
+                            processor_, params_,
+                            data_in_, dp_out_,
+                            data_out_,
+                            self._get_procesor_env())
                     return inner2
-                yield filename, inner(processor, params, data_in, dp_out, data_out)
+                yield filename, inner(processor, params,
+                                      data_in, dp_out, data_out)
 
     def _get_procesor_env(self):
         """
-        set the environment variables for the sub-process that runs the processor
-        extending classes will most likely want to set the PYTHONPATH variable to correct value
+        Set the environment variables for the sub-process that runs the
+        processor extending classes will most likely want to set the PYTHONPATH
+        variable to correct value
         """
         return {}
 
     def _get_processor_file(self, processor):
         """
-        should be implemented by extending classes to return the path to the processor python file
-        :param processor: the value of the 1st part of the fixture (the name of the processor to test)
+        Must be implemented by extending classes to return the path to the
+        processor python file.
+
+        :param processor: the value of the 1st part of the fixture (the name of
+            the processor to test)
         :return: full path to the processor python file
         """
         raise NotImplementedError()
@@ -53,24 +64,32 @@ class ProcessorFixtureTestsBase(object):
         return data_in, data_out, dp_out, params, processor_file
 
     @staticmethod
-    def test_single_fixture(processor, parameters, data_in, dp_out, data_out, env):
+    def test_single_fixture(processor, parameters, data_in,
+                            dp_out, data_out, env):
         """Test a single processor with the given fixture parameters"""
-        process = subprocess.run([sys.executable, processor, '1', parameters, 'False', ''],
-                                 input=data_in, stdout=subprocess.PIPE, env=env)
+        process = subprocess.run([sys.executable, processor, '1',
+                                  parameters, 'False', ''],
+                                 input=data_in,
+                                 stdout=subprocess.PIPE,
+                                 env=env)
         output = process.stdout.decode('utf8')
         (actual_dp, *actual_data) = output.split('\n\n', 1)
-        assert actual_dp == dp_out, "unexpected value for output datapackage: {}".format(actual_dp)
+        assert actual_dp == dp_out, \
+            "unexpected value for output datapackage: {}".format(actual_dp)
         if len(actual_data) > 0:
             actual_data = actual_data[0]
             actual_data = actual_data.split('\n')
             expected_data = data_out.split('\n')
             assert len(actual_data) == len(expected_data), \
-                "unexpected number of output lines: {}, actual_data = {}".format(len(actual_data), actual_data)
-            for line_num, (actual, expected) in enumerate(zip(actual_data, expected_data)):
+                "unexpected number of output lines: {}, actual_data = {}" \
+                .format(len(actual_data), actual_data)
+            for line_num, (actual, expected) in enumerate(zip(actual_data,
+                                                              expected_data)):
                 line_msg = "output line {}".format(line_num)
                 if len(actual) == 0:
                     assert len(expected) == 0, \
-                        "{}: did not get any data (but expected some)".format(line_msg)
+                        "{}: did not get any data (but expected some)" \
+                        .format(line_msg)
                 else:
                     rj_actual = rejsonize(actual)
                     assert rj_actual == rejsonize(expected), \


### PR DESCRIPTION
This PR moves the `test_single_fixture` function into the `ProcessorFixtureTestBase` class, allowing it to be overridable by subclasses.

This is useful when you want to test specific aspects of the returned data, for example that a returned value asserts against a regexp (uuid, for example).

Changes proposed in this pull request:

- Move `test_single_fixture` into `ProcessorFixtureTestBase` as a staticmethod
- Lint `lib_test_helpers` file for readability
