### PR TITLE
improve the logging of exception "Too large stats object!"

### DIFF
--- a/datapackage_pipelines/manager/tasks.py
+++ b/datapackage_pipelines/manager/tasks.py
@@ -46,7 +46,7 @@ async def collect_stats(infile):
         try:
             line = await reader.readline()
         except ValueError:
-            logging.error('Too large stats object!')
+            logging.exception('Too large stats object!')
             break
         if line == b'':
             break


### PR DESCRIPTION
#### reproduction steps
* run a processor that will cause "Too large stats object!" error

##### expected
* some details about the error / where it's coming from (e.g. traceback)
```
ERROR   :Main                            :Too large stats object!
Traceback (most recent call last):
  File "/home/ori/.pythonz/pythons/CPython-3.6.1/lib/python3.6/asyncio/streams.py", line 482, in readline
    line = yield from self.readuntil(sep)
  File "/home/ori/.pythonz/pythons/CPython-3.6.1/lib/python3.6/asyncio/streams.py", line 579, in readuntil
    'Separator is found, but chunk is longer than limit', isep)
asyncio.streams.LimitOverrunError: Separator is found, but chunk is longer than limit

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ori/datapackage-pipelines/datapackage_pipelines/manager/tasks.py", line 47, in collect_stats
    line = await reader.readline()
  File "/home/ori/.pythonz/pythons/CPython-3.6.1/lib/python3.6/asyncio/streams.py", line 491, in readline
    raise ValueError(e.args[0])
ValueError: Separator is found, but chunk is longer than limit
```

##### actual
no details, just the cryptic error message
```
ERROR   :Main                            :Too large stats object!
```
