### PR TITLE
prevent silent failure in case of plugin import error

### DIFF
--- a/datapackage_pipelines/specs/resolver.py
+++ b/datapackage_pipelines/specs/resolver.py
@@ -40,7 +40,7 @@ def load_module(module):
         module = __import__(module_name)
         return module
     except ImportError:
-        pass
+        logging.exception("failed to import datapackage pipelines module {}".format(module_name))
 
 
 def resolve_executor(step, path, errors):

--- a/datapackage_pipelines/specs/resolver.py
+++ b/datapackage_pipelines/specs/resolver.py
@@ -1,6 +1,8 @@
 import logging
 import os
 import hashlib
+from importlib.util import find_spec
+from importlib import import_module
 
 from .errors import SpecError
 
@@ -36,12 +38,8 @@ def convert_dot_notation(executor):
 
 def load_module(module):
     module_name = 'datapackage_pipelines_'+module
-    try:
-        module = __import__(module_name)
-        return module
-    except ImportError:
-        logging.exception("failed to import datapackage pipelines module {}".format(module_name))
-
+    if find_spec(module_name):
+        return import_module(module_name)
 
 def resolve_executor(step, path, errors):
 


### PR DESCRIPTION
### reproduction steps
* write a datapackage pipelines plugin to handle source descriptors (as described in [README](https://github.com/frictionlessdata/datapackage-pipelines/blob/master/README.md#plugins-and-source-descriptors))
* have an import error inside your datapackage pipelines plugin module
* e.g. try to import a non-existant module
* run `dpp`

#### expected
* error about the import error with exception trace
```
$ dpp
Available Pipelines:
ERROR   :Main                            :failed to import datapackage pipelines module datapackage_pipelines_mojp
Traceback (most recent call last):
  File "/home/ori/datapackage-pipelines/datapackage_pipelines/specs/resolver.py", line 40, in load_module
    module = __import__(module_name)
  File "/home/ori/mojp-dbs-pipelines/datapackage_pipelines_mojp/__init__.py", line 1, in <module>
    from .mojp_generator import MojpGenerator
  File "/home/ori/mojp-dbs-pipelines/datapackage_pipelines_mojp/mojp_generator.py", line 7, in <module>
    from settings import MOJP_ONLY_DOWNLOAD, MOJP_MOCK
ModuleNotFoundError: No module named 'settings'
- mojp (E)
	Unknown source kind: Unknown source description kind "mojp" in ./mojp.source-spec.yaml
```

#### actual
* silent failure, very hard to debug
```
$ dpp
Available Pipelines:
- mojp (E)
	Unknown source kind: Unknown source description kind "mojp" in ./mojp.source-spec.yaml
```
