### PR TITLE
Lazy load input for performance boosting

### DIFF
--- a/datapackage_pipelines/utilities/lazy_dict.py
+++ b/datapackage_pipelines/utilities/lazy_dict.py
@@ -1,0 +1,45 @@
+import collections
+
+
+class LazyDict(collections.MutableMapping):
+
+    def __init__(self):
+        self._inner = None
+        self._dirty = False
+
+    @property
+    def dirty(self):
+        return self._dirty
+
+    @property
+    def inner(self):
+        return self._inner
+
+    def _evaluate(self):
+        raise NotImplementedError()
+
+    def __ensure(self):
+        if self._inner is None:
+            self._inner = self._evaluate()
+
+    def __len__(self):
+        self.__ensure()
+        return len(self._inner)
+
+    def __getitem__(self, item):
+        self.__ensure()
+        return self._inner.__getitem__(item)
+
+    def __setitem__(self, key, value):
+        self.__ensure()
+        self._inner.__setitem__(key, value)
+        self._dirty = True
+
+    def __delitem__(self, key):
+        self.__ensure()
+        self._inner.__delitem__(key)
+        self._dirty = True
+
+    def __iter__(self):
+        self.__ensure()
+        return self._inner.__iter__()

--- a/datapackage_pipelines/wrapper/input_processor.py
+++ b/datapackage_pipelines/wrapper/input_processor.py
@@ -34,7 +34,7 @@ class ResourceIterator(object):
         if line == '':
             self.stopped = True
             raise StopIteration()
-        line = json.loads(line)
+        line = json.loadl(line)
         if self.validate:
             for k, v in line.items():
                 try:

--- a/datapackage_pipelines/wrapper/wrapper.py
+++ b/datapackage_pipelines/wrapper/wrapper.py
@@ -57,7 +57,7 @@ def spew(dp, resources_iterator, stats=None):
             for f in files:
                 f.write('\n')
             for rec in res:
-                line = json.dumps(rec,
+                line = json.dumpl(rec,
                                   sort_keys=True,
                                   ensure_ascii=True)
                 # logging.error('SPEWING: {}'.format(line))


### PR DESCRIPTION
By not json-decoding the input (until actually inspected) we avoid decoding and encoding json for such 'passthru' cases.