### PR TITLE
Allow processors to log and spew objects larger than 64K

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/

--- a/datapackage_pipelines/lib/internal/sink.py
+++ b/datapackage_pipelines/lib/internal/sink.py
@@ -1,0 +1,14 @@
+import collections
+
+from datapackage_pipelines.wrapper import ingest, spew
+
+params, dp, res_iter = ingest()
+
+
+def sink(res_iter_):
+    for res in res_iter_:
+        collections.deque(res, maxlen=0)
+        yield []
+
+
+spew(dp, sink(res_iter))

--- a/datapackage_pipelines/manager/tasks.py
+++ b/datapackage_pipelines/manager/tasks.py
@@ -20,7 +20,7 @@ async def enqueue_errors(step, process, queue):
         try:
             line = await out.readline()
         except ValueError:
-            logging.error('Received a too long log line (>64KB), truncated')
+            logging.error('Received a too long log line (>64KB), discarded')
             continue
         if line == b'':
             break

--- a/tests/env/common/pipeline-common.py
+++ b/tests/env/common/pipeline-common.py
@@ -1,0 +1,5 @@
+from datapackage_pipelines.wrapper import ingest, spew
+
+params, datapackage, res_iter = ingest()
+datapackage['profile'] = 'tabular-data-package'
+spew(datapackage, res_iter)

--- a/tests/env/dummy/big-outputs.py
+++ b/tests/env/dummy/big-outputs.py
@@ -1,0 +1,26 @@
+import logging
+import itertools
+import os
+
+from datapackage_pipelines.wrapper import ingest, spew
+
+params, dp, res_iter = ingest()
+
+big_string = 'z'*64*1024
+
+logging.info('Look at me %s', big_string)
+
+dp['name'] = 'a'
+dp['resources'].append({
+    'name': 'aa%f' % os.getpid(),
+    'path': 'data/bla.csv',
+    'schema': {
+        'fields': [
+            {'name': 'a', 'type': 'string'}
+        ]
+    }
+})
+
+res = iter([{'a': big_string}])
+
+spew(dp, itertools.chain(res_iter, [res]))

--- a/tests/env/dummy/pipeline-spec.yaml
+++ b/tests/env/dummy/pipeline-spec.yaml
@@ -1,0 +1,68 @@
+pipeline-test-basic:
+  pipeline:
+    -
+      run: add_metadata
+      parameters:
+        name: 'al-treasury-spending'
+        title: 'Albania Treasury Service'
+        granularity: transactional
+        countryCode: AL
+        homepage: 'http://spending.data.al/en/treasuryservice/list/year/2014/inst_code/1005001'
+    -
+      run: add_resource
+      parameters:
+        name: "treasury"
+        url: "https://raw.githubusercontent.com/openspending/fiscal-data-package-demos/master/al-treasury-spending/data/treasury.csv"
+        schema:
+          fields:
+            -
+              name: "Budget Institution"
+              type: string
+            -
+              name: "Supplier"
+              type: string
+            -
+              name: "Treasury Branch"
+              type: string
+            -
+              name: "Value"
+              type: number
+            -
+              name: "Date registered"
+              type: date
+            -
+              name: "Date executed"
+              type: date
+            -
+              name: "Receipt No"
+              type: string
+            -
+              name: "Kategori Shpenzimi"
+              type: string
+            -
+              name: "Receipt Description"
+              type: string
+    -
+      run: stream_remote_resources
+    -
+      run: pipeline-test-supplier-titleize
+      parameters:
+        key: Supplier
+    -
+      run: ..extract-year
+      parameters:
+         from-key: "Date executed"
+         to-key: "Year"
+    -
+      run: ..common.pipeline-common
+    -
+      run: dump.to_zip
+      parameters:
+          out-file: dump.zip
+
+
+pipeline-test-big-outputs:
+  pipeline:
+    - run: big-outputs
+    - run: big-outputs
+

--- a/tests/env/dummy/pipeline-test-supplier-titleize.py
+++ b/tests/env/dummy/pipeline-test-supplier-titleize.py
@@ -1,0 +1,17 @@
+from datapackage_pipelines.wrapper import ingest, spew
+
+params, datapackage, res_iter = ingest()
+
+key = params['key']
+
+
+def process_resources(_res_iter):
+    for res in _res_iter:
+        def process_res(_res):
+            for line in _res:
+                if key in line:
+                    line[key] = line[key].title()
+                    yield line
+        yield process_res(res)
+
+spew(datapackage, process_resources(res_iter))

--- a/tests/env/extract-year.py
+++ b/tests/env/extract-year.py
@@ -1,0 +1,27 @@
+from datapackage_pipelines.wrapper import ingest, spew
+
+params, datapackage, res_iter = ingest()
+
+from_key = params['from-key']
+to_key = params['to-key']
+
+
+def process_resources(_res_iter):
+    for res in _res_iter:
+        def process_res(_res):
+            for line in _res:
+                if from_key in line:
+                    line[to_key] = line[from_key].year
+                    yield line
+    yield process_res(res)
+
+
+for resource in datapackage['resources']:
+    if len(list(filter(lambda field: field['name'] == from_key, resource.get('schema',{}).get('fields',[])))) > 0:
+        resource['schema']['fields'].append({
+            'name': to_key,
+            'osType': 'date:fiscal-year',
+            'type': 'integer'
+        })
+
+spew(datapackage, process_resources(res_iter))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,7 +5,8 @@ from datapackage_pipelines.specs.specs import pipelines
 
 
 def test_pipeline():
-    '''Tests that what we want for open data is correct.'''
+    '''Tests a few pipelines.'''
     for spec in pipelines():
-        if spec.pipeline_id == './tests/env/dummy/pipeline-test':
-            execute_pipeline(spec, use_cache=False)
+        if spec.pipeline_id.startswith('./tests/env/dummy/pipeline-test'):
+            success, _ = execute_pipeline(spec, use_cache=False)
+            assert success


### PR DESCRIPTION
This pull request handles 2 issues:
- Logging lines larger than 64KB
- Spewing data larger than 64KB

The main problem is that the manager uses the asyncio framework which imposes hard limits on line sizes (as it's an async framework). Processors themselves don't have that problem as they work synchronously. 

The 1st issue is handled by detecting such cases and showing a friendly message to the user (the original log line is discarded).
The 2nd issue is resolved by adding a 'sink' processor to every pipeline which makes sure that no large objects are passed to the manager. 

(Also added a few missing tests which were clouded by a bad gitignore rule)