### PR TITLE
Add env in add resource url

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ _Parameters_:
 
 You should provide the `name` and `url` attributes, and other optional attributes as defined in the [spec]([http://specs.frictionlessdata.io/data-packages/#resource-information).
 
-Note that `url` also supports supports `env://<environment-variable>`, which indicates that the resource url should be fetched from the indicated environment variable.  This is useful in case you are supplying a string with sensitive information (such as an SQL connection string for streaming from a database table).
+Note that `url` also supports `env://<environment-variable>`, which indicates that the resource url should be fetched from the indicated environment variable.  This is useful in case you are supplying a string with sensitive information (such as an SQL connection string for streaming from a database table).
 
 Parameters are basically arguments that are passed to a `tabulator.Stream` instance (see the [API](https://github.com/frictionlessdata/tabulator-py#api-reference)).
 Other than those, you can pass a `constants` parameter which should be a mapping of headers to string values.

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ _Parameters_:
 
 You should provide the `name` and `url` attributes, and other optional attributes as defined in the [spec]([http://specs.frictionlessdata.io/data-packages/#resource-information).
 
+Note that `url` also supports supports `env://<environment-variable>`, which indicates that the resource url should be fetched from the indicated environment variable.  This is useful in case you are supplying a string with sensitive information (such as an SQL connection string for streaming from a database table).
+
 Parameters are basically arguments that are passed to a `tabulator.Stream` instance (see the [API](https://github.com/frictionlessdata/tabulator-py#api-reference)).
 Other than those, you can pass a `constants` parameter which should be a mapping of headers to string values.
 When used in conjunction with `stream_remote_resources`, these constant values will be added to each generated row 

--- a/datapackage_pipelines/lib/add_resource.py
+++ b/datapackage_pipelines/lib/add_resource.py
@@ -1,4 +1,5 @@
 from datapackage_pipelines.wrapper import ingest, spew
+import os
 
 parameters, datapackage, res_iter = ingest()
 
@@ -10,6 +11,16 @@ datapackage.setdefault('resources', [])
 
 assert 'path' not in parameters, \
     "You can only add remote resources using this processor"
+
+if parameters['url'].startswith('env://'):
+    env_var = parameters['url'][6:]
+    env_url = os.environ.get(env_var)
+    assert env_url is not None, \
+        "Couldn't connect to resource URL - " \
+        "Please set your '%s' environment variable" % env_var
+
+    parameters['url'] = env_url
+
 for param in ['url', 'name']:
     assert param in parameters, \
         "You must define {} in your parameters".format(param)

--- a/datapackage_pipelines/lib/stream_remote_resources.py
+++ b/datapackage_pipelines/lib/stream_remote_resources.py
@@ -189,14 +189,6 @@ for resource in datapackage['resources']:
         new_resource_iterator.append(next(resource_iterator))
     elif 'url' in resource:
         url = resource['url']
-        if url.startswith('env://'):
-            env_var = url[6:]
-            engine = os.environ.get(env_var)
-            assert engine is not None, \
-                "Couldn't connect to DB - " \
-                "Please set your '%s' environment variable" % env_var
-
-            url = engine
 
         name = resource['name']
         if not resources.match(name):

--- a/tests/stdlib/fixtures/add_resource_existent_env
+++ b/tests/stdlib/fixtures/add_resource_existent_env
@@ -1,0 +1,24 @@
+add_resource
+--
+{
+    "name": "my-empty-env-resource",
+    "url": "env://EXISTENT_ENV"
+}
+--
+{
+    "name": "test",
+    "resources": []
+}
+--
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "name": "my-empty-env-resource",
+            "url": "file://tests/data/sample.csv"
+        }
+    ]
+}
+--
+{}

--- a/tests/stdlib/fixtures/add_resource_existent_env
+++ b/tests/stdlib/fixtures/add_resource_existent_env
@@ -1,7 +1,7 @@
 add_resource
 --
 {
-    "name": "my-empty-env-resource",
+    "name": "my-env-resource",
     "url": "env://EXISTENT_ENV"
 }
 --

--- a/tests/stdlib/fixtures/add_resource_existent_env
+++ b/tests/stdlib/fixtures/add_resource_existent_env
@@ -15,7 +15,7 @@ add_resource
     "name": "test",
     "resources": [
         {
-            "name": "my-empty-env-resource",
+            "name": "my-env-resource",
             "url": "file://tests/data/sample.csv"
         }
     ]

--- a/tests/stdlib/test_stdlib.py
+++ b/tests/stdlib/test_stdlib.py
@@ -5,6 +5,7 @@ ROOT_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 ENV = os.environ.copy()
 ENV['PYTHONPATH'] = ROOT_PATH
 
+ENV['EXISTENT_ENV'] = 'file://tests/data/sample.csv'
 
 class StdlibfixtureTests(ProcessorFixtureTestsBase):
 


### PR DESCRIPTION
Typo

This pull request fixes #71 .

* [x] I've added tests to cover the proposed changes

Changes proposed in this pull request:

- Adds ability to add a resource URL that points to an environment variable
- Adds documentation to README about the above

