### PR TITLE
Add support for running tests on other databases (tested with PostgreSQL)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,3 +63,13 @@ All positional arguments and options after `--` will be passed to `py.test`:
 ```
 tox -e py35 -- -v tests/<path>
 ```
+
+## Testing with other databases
+
+By default the tests run with sqlite in-memory database which doesn't require any setup.
+However, most projects will want to use a real DB, like PostgreSQL.
+
+To run the tests with a different DB, you need to supply the connection string via environment variable.
+For example, to run with local postgresql databsae:
+
+`OVERRIDE_TEST_DB=postgresql://postgres:123456@localhost:5432/postgres py.test`

--- a/datapackage_pipelines/lib/filter.py
+++ b/datapackage_pipelines/lib/filter.py
@@ -1,9 +1,5 @@
-import re
-import logging
-
 from datapackage_pipelines.wrapper import ingest, spew
 from datapackage_pipelines.utilities.resource_matcher import ResourceMatcher
-import jsontableschema
 
 import operator
 

--- a/datapackage_pipelines/utilities/lib_test_helpers.py
+++ b/datapackage_pipelines/utilities/lib_test_helpers.py
@@ -26,9 +26,8 @@ class ProcessorFixtureTestsBase(object):
 
     def _get_test_func(self, processor, params, data_in, dp_out, data_out, filename):
         def inner():
-            def inner2():
-                return self._test_single_fixture(processor, params, data_in, dp_out, data_out, self._get_procesor_env(filename))
-            return inner2
+            return self._test_single_fixture(processor, params, data_in, dp_out, data_out,
+                                             self._get_procesor_env(filename))
         return inner
 
     def _get_procesor_env(self, filename):
@@ -36,7 +35,7 @@ class ProcessorFixtureTestsBase(object):
         Set the environment variables for the sub-process that runs the
         processor extending classes will most likely want to set the PYTHONPATH
         variable to correct value
-        you can use the filename param to setup DB or other dependencies differently for each fixture 
+        you can use the filename param to setup DB or other dependencies differently for each fixture
         """
         return {}
 

--- a/datapackage_pipelines/utilities/lib_test_helpers.py
+++ b/datapackage_pipelines/utilities/lib_test_helpers.py
@@ -21,25 +21,22 @@ class ProcessorFixtureTestsBase(object):
     def get_tests(self):
         for dirpath, _, filenames in os.walk(self._fixtures_path):
             for filename in filenames:
-                data_in, data_out, dp_out, params, processor = \
-                    self._load_fixture(dirpath, filename)
+                data_in, data_out, dp_out, params, processor = self._load_fixture(dirpath, filename)
+                yield filename, self._get_test_func(processor, params, data_in, dp_out, data_out, filename)
 
-                def inner(processor_, params_, data_in_, dp_out_, data_out_):
-                    def inner2():
-                        return self._test_single_fixture(
-                            processor_, params_,
-                            data_in_, dp_out_,
-                            data_out_,
-                            self._get_procesor_env())
-                    return inner2
-                yield filename, inner(processor, params,
-                                      data_in, dp_out, data_out)
+    def _get_test_func(self, processor, params, data_in, dp_out, data_out, filename):
+        def inner():
+            def inner2():
+                return self._test_single_fixture(processor, params, data_in, dp_out, data_out, self._get_procesor_env(filename))
+            return inner2
+        return inner
 
-    def _get_procesor_env(self):
+    def _get_procesor_env(self, filename):
         """
         Set the environment variables for the sub-process that runs the
         processor extending classes will most likely want to set the PYTHONPATH
         variable to correct value
+        you can use the filename param to setup DB or other dependencies differently for each fixture 
         """
         return {}
 

--- a/tests/stdlib/fixtures/dump_to_sql_update_mode__insert
+++ b/tests/stdlib/fixtures/dump_to_sql_update_mode__insert
@@ -3,7 +3,8 @@ dump.to_sql
 {
     "tables": {
         "test": {
-            "resource-name": "my-spiffy-resource"
+            "resource-name": "my-spiffy-resource",
+            "mode": "update"
         }
     }
 }
@@ -16,17 +17,18 @@ dump.to_sql
             "path": "data/my-data.csv",
             "schema": {
                 "fields": [
+                    {"name": "id", "type": "integer"},
                     {"name": "mystring", "type": "string"},
-                    {"name": "myinteger", "type": "integer"},
                     {"name": "mynumber", "type": "number"},
                     {"name": "mydate", "type": "date"}
-                ]
+                ],
+                "primaryKey": ["id"]
             }
         }
     ]
 }
 --
-{"mystring":"a", "mynumber": 2.0, "mydate": {"type{date}": "2016-12-31"}}
+{"id": 1, "mystring":"a", "mynumber": 2.0, "mydate": {"type{date}": "2016-12-31"}}
 --
 {
     "name": "test",
@@ -36,16 +38,17 @@ dump.to_sql
             "path": "data/my-data.csv",
             "schema": {
                 "fields": [
+                    {"name": "id", "type": "integer"},
                     {"name": "mystring", "type": "string"},
-                    {"name": "myinteger", "type": "integer"},
                     {"name": "mynumber", "type": "number"},
                     {"name": "mydate", "type": "date"}
-                ]
+                ],
+                "primaryKey": ["id"]
             }
         }
     ]
 }
 --
-{"mystring":"a", "mynumber": 2.0, "mydate": {"type{date}": "2016-12-31"}}
+{"id": 1, "mystring":"a", "mynumber": 2.0, "mydate": {"type{date}": "2016-12-31"}}
 
 {"dataset_name": "test", "count_of_rows": 1, "bytes": null}

--- a/tests/stdlib/fixtures/dump_to_sql_update_mode__update
+++ b/tests/stdlib/fixtures/dump_to_sql_update_mode__update
@@ -3,7 +3,8 @@ dump.to_sql
 {
     "tables": {
         "test": {
-            "resource-name": "my-spiffy-resource"
+            "resource-name": "my-spiffy-resource",
+            "mode": "update"
         }
     }
 }
@@ -16,17 +17,18 @@ dump.to_sql
             "path": "data/my-data.csv",
             "schema": {
                 "fields": [
+                    {"name": "id", "type": "integer"},
                     {"name": "mystring", "type": "string"},
-                    {"name": "myinteger", "type": "integer"},
                     {"name": "mynumber", "type": "number"},
                     {"name": "mydate", "type": "date"}
-                ]
+                ],
+                "primaryKey": ["id"]
             }
         }
     ]
 }
 --
-{"mystring":"a", "mynumber": 2.0, "mydate": {"type{date}": "2016-12-31"}}
+{"id": 1, "mystring":"a", "mynumber": 2.0, "mydate": {"type{date}": "2016-12-31"}}
 --
 {
     "name": "test",
@@ -36,16 +38,17 @@ dump.to_sql
             "path": "data/my-data.csv",
             "schema": {
                 "fields": [
+                    {"name": "id", "type": "integer"},
                     {"name": "mystring", "type": "string"},
-                    {"name": "myinteger", "type": "integer"},
                     {"name": "mynumber", "type": "number"},
                     {"name": "mydate", "type": "date"}
-                ]
+                ],
+                "primaryKey": ["id"]
             }
         }
     ]
 }
 --
-{"mystring":"a", "mynumber": 2.0, "mydate": {"type{date}": "2016-12-31"}}
+{"id": 1, "mystring":"a", "mynumber": 2.0, "mydate": {"type{date}": "2016-12-31"}}
 
 {"dataset_name": "test", "count_of_rows": 1, "bytes": null}

--- a/tests/stdlib/fixtures/dump_to_sql_with_updated_data
+++ b/tests/stdlib/fixtures/dump_to_sql_with_updated_data
@@ -1,7 +1,6 @@
 dump.to_sql
 --
 {
-    "engine": "sqlite://",
     "tables": {
         "test": {
             "resource-name": "my-spiffy-resource"

--- a/tests/stdlib/fixtures/obj_fix_dump_to_sql
+++ b/tests/stdlib/fixtures/obj_fix_dump_to_sql
@@ -1,6 +1,10 @@
 dump.to_sql
 --
 {
+    "comment": [
+        "this test involves data types which work differently in sqlite and postgresql",
+        "so, forcing sqlite engine here"
+    ],
     "engine": "sqlite://",
     "tables": {
         "test": {

--- a/tests/stdlib/test_stdlib.py
+++ b/tests/stdlib/test_stdlib.py
@@ -20,16 +20,17 @@ class StdlibfixtureTests(ProcessorFixtureTestsBase):
             engine = create_engine(ENV['DPP_DB_ENGINE'])
             engine.execute(text("DROP TABLE IF EXISTS test;"))
         if filename == "dump_to_sql_update_mode__update":
+            engine = create_engine(ENV['DPP_DB_ENGINE'])
             engine.execute(text("""
                 CREATE TABLE test (
-                  id integet not null primary key,
+                  id integer not null primary key,
                   mystring text,
                   mynumber double precision,
                   mydate date
                 )
             """))
             engine.execute(text("""
-                INSERT INTO text VALUES (1, "foo", 5.6, null);
+                INSERT INTO test VALUES (1, 'foo', 5.6, null);
             """))
         return ENV
 

--- a/tests/stdlib/test_stdlib.py
+++ b/tests/stdlib/test_stdlib.py
@@ -1,5 +1,7 @@
-import os
+import os, logging
 from datapackage_pipelines.utilities.lib_test_helpers import ProcessorFixtureTestsBase
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy import create_engine, text
 
 ROOT_PATH = os.path.join(os.path.dirname(__file__), '..', '..')
 ENV = os.environ.copy()
@@ -7,9 +9,28 @@ ENV['PYTHONPATH'] = ROOT_PATH
 
 ENV['EXISTENT_ENV'] = 'file://tests/data/sample.csv'
 
+DEFAULT_TEST_DB = "sqlite://"
+ENV['DPP_DB_ENGINE'] = os.environ.get("OVERRIDE_TEST_DB", DEFAULT_TEST_DB)
+
+
 class StdlibfixtureTests(ProcessorFixtureTestsBase):
 
-    def _get_procesor_env(self):
+    def _get_procesor_env(self, filename):
+        if ENV['DPP_DB_ENGINE'] != DEFAULT_TEST_DB:
+            engine = create_engine(ENV['DPP_DB_ENGINE'])
+            engine.execute(text("DROP TABLE IF EXISTS test;"))
+        if filename == "dump_to_sql_update_mode__update":
+            engine.execute(text("""
+                CREATE TABLE test (
+                  id integet not null primary key,
+                  mystring text,
+                  mynumber double precision,
+                  mydate date
+                )
+            """))
+            engine.execute(text("""
+                INSERT INTO text VALUES (1, "foo", 5.6, null);
+            """))
         return ENV
 
     def _get_processor_file(self, processor):


### PR DESCRIPTION
### reproduction
* have a bug with occurs only on PostgreSQL

#### expected
* should have a way to run the tests with PostgreSQL database

#### actual
* tests only run on in-memory sqlite DB