### PR TITLE
keep resource source as dpp:streamedFrom property

### DIFF
--- a/datapackage_pipelines/lib/load_resource.py
+++ b/datapackage_pipelines/lib/load_resource.py
@@ -4,7 +4,8 @@ import datapackage
 
 from datapackage_pipelines.wrapper import ingest, spew
 from datapackage_pipelines.utilities.resource_matcher import ResourceMatcher
-from datapackage_pipelines.utilities.resources import tabular, PROP_STREAMING
+from datapackage_pipelines.utilities.resources import tabular, PROP_STREAMING, \
+    PROP_STREAMED_FROM
 
 
 class ResourceLoader(object):
@@ -26,6 +27,7 @@ class ResourceLoader(object):
             if resource_index == i or \
                     (name_matcher is not None and name_matcher.match(orig_res.descriptor.get('name'))):
                 found = True
+                orig_res.descriptor[PROP_STREAMED_FROM] = url
                 self.dp['resources'].append(orig_res.descriptor)
                 if tabular(orig_res.descriptor) and stream:
                     orig_res.descriptor[PROP_STREAMING] = True

--- a/datapackage_pipelines/lib/load_resource.py
+++ b/datapackage_pipelines/lib/load_resource.py
@@ -27,7 +27,7 @@ class ResourceLoader(object):
             if resource_index == i or \
                     (name_matcher is not None and name_matcher.match(orig_res.descriptor.get('name'))):
                 found = True
-                orig_res.descriptor[PROP_STREAMED_FROM] = url
+                orig_res.descriptor[PROP_STREAMED_FROM] = orig_res.source
                 self.dp['resources'].append(orig_res.descriptor)
                 if tabular(orig_res.descriptor) and stream:
                     orig_res.descriptor[PROP_STREAMING] = True

--- a/datapackage_pipelines/utilities/lib_test_helpers.py
+++ b/datapackage_pipelines/utilities/lib_test_helpers.py
@@ -59,7 +59,7 @@ class ProcessorFixtureTestsBase(object):
         # Hacky way to form cwd for resource path and ignore  other formating like %Y-%m-%d
         try:
             dp_out = dp_out % ({"base": os.getcwd()})
-        except:
+        except: #noqa
             pass
         dp_out = rejsonize(dp_out)
         dp_in = rejsonize(dp_in)

--- a/datapackage_pipelines/utilities/lib_test_helpers.py
+++ b/datapackage_pipelines/utilities/lib_test_helpers.py
@@ -56,6 +56,11 @@ class ProcessorFixtureTestsBase(object):
         processor, params, dp_in, data_in, dp_out, data_out = parts
         processor_file = self._get_processor_file(processor)
         params = rejsonize(params)
+        # Hacky way to form cwd for resource path and ignore  other formating like %Y-%m-%d
+        try:
+            dp_out = dp_out % ({"base": os.getcwd()})
+        except:
+            pass
         dp_out = rejsonize(dp_out)
         dp_in = rejsonize(dp_in)
         data_in = (dp_in + '\n\n' + data_in).encode('utf8')

--- a/tests/stdlib/fixtures/simple_load_resource
+++ b/tests/stdlib/fixtures/simple_load_resource
@@ -15,7 +15,7 @@ load_resource
     "name": "test",
     "resources": [
         {
-            "dpp:streamedFrom": "tests/data/datapackage.json",
+            "dpp:streamedFrom": "%(base)s/tests/data/sample.csv",
             "name": "my-spiffy-resource",
             "dpp:streaming": true,
             "profile": "data-resource",

--- a/tests/stdlib/fixtures/simple_load_resource
+++ b/tests/stdlib/fixtures/simple_load_resource
@@ -15,6 +15,7 @@ load_resource
     "name": "test",
     "resources": [
         {
+            "dpp:streamedFrom": "tests/data/datapackage.json",
             "name": "my-spiffy-resource",
             "dpp:streaming": true,
             "profile": "data-resource",

--- a/tests/stdlib/fixtures/simple_load_resource_index
+++ b/tests/stdlib/fixtures/simple_load_resource_index
@@ -15,7 +15,7 @@ load_resource
     "name": "test",
     "resources": [
         {
-            "dpp:streamedFrom": "tests/data/datapackage.json",
+            "dpp:streamedFrom": "%(base)s/tests/data/sample.csv",
             "name": "my-spiffy-resource",
             "dpp:streaming": true,
             "profile": "data-resource",

--- a/tests/stdlib/fixtures/simple_load_resource_index
+++ b/tests/stdlib/fixtures/simple_load_resource_index
@@ -15,6 +15,7 @@ load_resource
     "name": "test",
     "resources": [
         {
+            "dpp:streamedFrom": "tests/data/datapackage.json",
             "name": "my-spiffy-resource",
             "dpp:streaming": true,
             "profile": "data-resource",

--- a/tests/stdlib/fixtures/simple_load_resource_multi
+++ b/tests/stdlib/fixtures/simple_load_resource_multi
@@ -15,6 +15,7 @@ load_resource
     "name": "test",
     "resources": [
         {
+            "dpp:streamedFrom": "tests/data/datapackage2.json",
             "name": "the-spiffy-resource",
             "dpp:streaming": true,
             "profile": "data-resource",
@@ -30,6 +31,7 @@ load_resource
             }
         },
         {
+            "dpp:streamedFrom": "tests/data/datapackage2.json",
             "name": "the-other-spiffy-resource",
             "dpp:streaming": true,
             "profile": "data-resource",

--- a/tests/stdlib/fixtures/simple_load_resource_multi
+++ b/tests/stdlib/fixtures/simple_load_resource_multi
@@ -15,7 +15,7 @@ load_resource
     "name": "test",
     "resources": [
         {
-            "dpp:streamedFrom": "tests/data/datapackage2.json",
+            "dpp:streamedFrom": "%(base)s/tests/data/sample.csv",
             "name": "the-spiffy-resource",
             "dpp:streaming": true,
             "profile": "data-resource",
@@ -31,7 +31,7 @@ load_resource
             }
         },
         {
-            "dpp:streamedFrom": "tests/data/datapackage2.json",
+            "dpp:streamedFrom": "%(base)s/tests/data/sample2.csv",
             "name": "the-other-spiffy-resource",
             "dpp:streaming": true,
             "profile": "data-resource",


### PR DESCRIPTION
In various cases, we need to keep the path to resource for future use. Saving it as `dpp:streamedFrom` property of the resource. 

Note: I would ignore first commit as it does completely wrong thing