### PR TITLE
added `api/raw/status` server endpoint

### DIFF
--- a/datapackage_pipelines/web/server.py
+++ b/datapackage_pipelines/web/server.py
@@ -126,8 +126,10 @@ def main():
 def pipeline_raw_api_status():
     pipelines = sorted(status.all_statuses(), key=lambda x: x.get('id'))
     for pipeline in pipelines:
-        # can get the full pipeline from api/raw/<path:pipeline_id>
-        del pipeline["pipeline"]
+        # can get the full details from api/raw/<path:pipeline_id>
+        for attr in ["pipeline", "reason", "error_log"]:
+            if attr in pipeline:
+                del pipeline[attr]
     return jsonify(pipelines)
 
 

--- a/datapackage_pipelines/web/server.py
+++ b/datapackage_pipelines/web/server.py
@@ -122,6 +122,15 @@ def main():
                            markdown=markdown)
 
 
+@blueprint.route("api/raw/status")
+def pipeline_raw_api_status():
+    pipelines = sorted(status.all_statuses(), key=lambda x: x.get('id'))
+    for pipeline in pipelines:
+        # can get the full pipeline from api/raw/<path:pipeline_id>
+        del pipeline["pipeline"]
+    return jsonify(pipelines)
+
+
 @blueprint.route("api/raw/<path:pipeline_id>")
 def pipeline_raw_api(pipeline_id):
     if not pipeline_id.startswith('./'):


### PR DESCRIPTION
added `api/raw/status` to the server routes, it returns all the pipelines statuses

it contains only the overview, with more detailed attributes available via the `api/raw/<pipeline_id>` endpoint

it has many use-cases for automation, some examples - 
* external monitoring / alerts regarding total number of currently running pipelines / failures
* develop alternative frontends - external to the pipelines app
* autoscaling based on number of pipelines waiting to run
