### PR TITLE
Allow processing datapackage

### DIFF
--- a/datapackage_pipelines/lib/load_resource.py
+++ b/datapackage_pipelines/lib/load_resource.py
@@ -28,6 +28,7 @@ class ResourceLoader(object):
         selected_resources = []
         found = False
         dp = datapackage.DataPackage(url)
+        dp = self.process_datapackage(dp)
         for i, orig_res in enumerate(dp.resources):
             if resource_index == i or \
                     (name_matcher is not None and name_matcher.match(orig_res.descriptor.get('name'))):
@@ -42,6 +43,9 @@ class ResourceLoader(object):
 
         assert found, "Failed to find resource with index or name matching %r" % resource
         spew(self.dp, itertools.chain(self.res_iter, selected_resources))
+
+    def process_datapackage(self, dp_):
+        return dp_
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In some cases, we might need to load and stream resources from private s3 objects. PR allows inheriting from stdlib and use it's `process_datapackage` method for Eg changing regular URLs for the resources with s3 pre-signed URLs.  
*Note: it will do nothing in base class*