### PR TITLE
sort processor - support rows with duplicate keys

### DIFF
--- a/datapackage_pipelines/lib/sort.py
+++ b/datapackage_pipelines/lib/sort.py
@@ -21,7 +21,7 @@ key_calc = KeyCalc(parameters['sort-by'])
 def sorter(resource):
     db = KVStore()
     for row_num, row in enumerate(resource):
-        key = key_calc(row) + "-{}".format(row_num)
+        key = key_calc(row) + "{:08x}".format(row_num)
         db[key] = row
     for key in db.keys():
         yield db[key]

--- a/datapackage_pipelines/lib/sort.py
+++ b/datapackage_pipelines/lib/sort.py
@@ -22,9 +22,10 @@ def sorter(resource):
     db = KVStore()
     for row in resource:
         key = key_calc(row)
-        db[key] = row
+        db.setdefault(key, []).append(row)
     for key in db.keys():
-        yield db[key]
+        for row in db[key]:
+            yield row
 
 
 def new_resource_iterator(resource_iterator_):

--- a/datapackage_pipelines/lib/sort.py
+++ b/datapackage_pipelines/lib/sort.py
@@ -20,12 +20,11 @@ key_calc = KeyCalc(parameters['sort-by'])
 
 def sorter(resource):
     db = KVStore()
-    for row in resource:
-        key = key_calc(row)
-        db.setdefault(key, []).append(row)
+    for row_num, row in enumerate(resource):
+        key = key_calc(row) + "-{}".format(row_num)
+        db[key] = row
     for key in db.keys():
-        for row in db[key]:
-            yield row
+        yield db[key]
 
 
 def new_resource_iterator(resource_iterator_):

--- a/tests/stdlib/fixtures/sort_with_duplicate_keys
+++ b/tests/stdlib/fixtures/sort_with_duplicate_keys
@@ -20,10 +20,18 @@ sort
     ]
 }
 --
-{"year":"2016","data":"foo"}
-{"year":"2017","data":"baz"}
-{"year":"2017","data":"bax"}
-{"year":"2015","data":""}
+{"year":"2016","data":"foo","i":0}
+{"year":"2017","data":"baz","i":1}
+{"year":"2017","data":"bax","i":2}
+{"year":"2015","data":"","i":3}
+{"year":"2015","data":"","i":4}
+{"year":"2015","data":"","i":5}
+{"year":"2015","data":"","i":6}
+{"year":"2015","data":"","i":7}
+{"year":"2015","data":"","i":8}
+{"year":"2015","data":"","i":9}
+{"year":"2015","data":"","i":10}
+{"year":"2015","data":"","i":11}
 --
 {
     "name": "test",
@@ -40,9 +48,17 @@ sort
     ]
 }
 --
-{"year":"2015","data":""}
-{"year":"2016","data":"foo"}
-{"year":"2017","data":"baz"}
-{"year":"2017","data":"bax"}
+{"year":"2015","data":"","i":3}
+{"year":"2015","data":"","i":4}
+{"year":"2015","data":"","i":5}
+{"year":"2015","data":"","i":6}
+{"year":"2015","data":"","i":7}
+{"year":"2015","data":"","i":8}
+{"year":"2015","data":"","i":9}
+{"year":"2015","data":"","i":10}
+{"year":"2015","data":"","i":11}
+{"year":"2016","data":"foo","i":0}
+{"year":"2017","data":"baz","i":1}
+{"year":"2017","data":"bax","i":2}
 
 {}

--- a/tests/stdlib/fixtures/sort_with_duplicate_keys
+++ b/tests/stdlib/fixtures/sort_with_duplicate_keys
@@ -1,0 +1,48 @@
+sort
+--
+{
+    "resources": ["data"],
+    "sort-by": "{year}"
+}
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "name": "data",
+            "dpp:streaming": true,
+            "path": "data.csv",
+            "schema": { "fields": [
+                {"name": "year", "type": "integer"},
+                {"name": "data", "type": "string"}
+            ]}
+        }
+    ]
+}
+--
+{"year":"2016","data":"foo"}
+{"year":"2017","data":"baz"}
+{"year":"2017","data":"bax"}
+{"year":"2015","data":""}
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "name": "data",
+            "dpp:streaming": true,
+            "path": "data.csv",
+            "schema": { "fields": [
+                {"name": "year", "type": "integer"},
+                {"name": "data", "type": "string"}
+            ]}
+        }
+    ]
+}
+--
+{"year":"2015","data":""}
+{"year":"2016","data":"foo"}
+{"year":"2017","data":"baz"}
+{"year":"2017","data":"bax"}
+
+{}


### PR DESCRIPTION
### reproduction
* use the `sort` processor on rows which have duplicate keys

#### expected
* keep all rows and in case of duplicate keys - keep the rows under the same key in the order in which they appeared

#### actual
* rows with duplicate keys are not yielded and only the last row is yielded for each key