### PR TITLE
pretty-descriptor option for FileDumper

### DIFF
--- a/README.md
+++ b/README.md
@@ -991,7 +991,7 @@ _Parameters_:
 
 - `force-format` - Specifies whether to force all output files to be generated with the same format
     - if `true` (the default), all resources will use the same format
-    - if `false`, format will be deduced from the file extension. Resources with unknown extenstions will be discrarded.
+    - if `false`, format will be deduced from the file extension. Resources with unknown extensions will be discarded.
 - `format` - Specifies the type of output files to be generated (if `force-format` is true): `csv` (the default) or `json`
 - `handle-non-tabular` - Specifies whether non tabular resources (i.e. resources without a `schema`) should be dumped as well to the resulting datapackage.
     (See note below for more details)
@@ -1007,6 +1007,9 @@ _Parameters_:
     - `resource-hash`: Where should an md5 hash of each resource be stored (default: `hash`)
     Each of these attributes could be set to null in order to prevent the counting.
     Each property could be a dot-separated string, for storing the data inside a nested object (e.g. `stats.rowcount`)
+- `pretty-descriptor`: Specifies how datapackage descriptor (`datapackage.json`) file will look like:
+    - `False` (default) - descriptor will be written in one line.
+    - `True` - descriptor will have indents and new lines for each key, so it becomes more human-readable.
 
 ### ***`dump.to_zip`***
 
@@ -1019,6 +1022,7 @@ _Parameters_:
 - `handle-non-tabular` - Same as in `dump.to_path`
 - `add-filehash-to-path` - Same as in `dump.to_path`
 - `counters` - Same as in `dump.to_path`
+- `pretty-descriptor` - Same as in `dump.to_path`
 
 #### *Note*
 

--- a/datapackage_pipelines/lib/dump/dumper_base.py
+++ b/datapackage_pipelines/lib/dump/dumper_base.py
@@ -140,6 +140,7 @@ class DumperBase(object):
         if self.datapackage_hash:
             datapackage_hash = hashlib.md5(
                         json.dumps(datapackage,
+                                   indent=2 if parameters.get('pretty-descriptor') else None,
                                    sort_keys=True,
                                    ensure_ascii=True).encode('ascii')
                     ).hexdigest()
@@ -197,7 +198,8 @@ class FileDumper(DumperBase):
         if parameters.get('handle-non-tabular', False):
             self.copy_non_tabular_resources(datapackage)
         temp_file = tempfile.NamedTemporaryFile(mode="w+", delete=False, encoding='utf-8')
-        json.dump(datapackage, temp_file, sort_keys=True, ensure_ascii=False)
+        indent = 2 if parameters.get('pretty-descriptor') else None
+        json.dump(datapackage, temp_file, indent=indent, sort_keys=True, ensure_ascii=False)
         temp_file_name = temp_file.name
         filesize = temp_file.tell()
         temp_file.close()

--- a/tests/stdlib/fixtures/simple_dump_to_zip_with_hash_&_pretty_descriptor
+++ b/tests/stdlib/fixtures/simple_dump_to_zip_with_hash_&_pretty_descriptor
@@ -1,0 +1,60 @@
+dump.to_zip
+--
+{
+    "out-file": "my-spiffy-resource.zip",
+    "add-filehash-to-path": true,
+    "pretty-descriptor": true
+}
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "name": "my-spiffy-resource",
+            "dpp:streaming": true,
+            "path": "data/my-data.csv",
+            "schema": {
+                "fields": [
+                    {"name": "mystring", "type": "string"},
+                    {"name": "myinteger", "type": "integer"},
+                    {"name": "mynumber", "type": "number"},
+                    {"name": "mydate", "type": "date"}
+                ]
+            }
+        }
+    ]
+}
+--
+{"mystring":"a", "mynumber": 2.0, "mydate": {"type{date}": "2016-12-31"}}
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "name": "my-spiffy-resource",
+            "dpp:streaming": true,
+            "path": "data/my-data.csv",
+            "encoding": "utf-8",
+            "format": "csv",
+            "dialect": {
+                "delimiter": ",",
+                "doubleQuote": true,
+                "lineTerminator": "\r\n",
+                "quoteChar": "\"",
+                "skipInitialSpace": false
+            },
+            "schema": {
+                "fields": [
+                    {"name": "mystring", "type": "string"},
+                    {"name": "myinteger", "type": "integer"},
+                    {"name": "mynumber", "type": "number", "groupChar": "", "decimalChar": "."},
+                    {"format": "%Y-%m-%d", "name": "mydate", "type": "date"}
+                ]
+            }
+        }
+    ]
+}
+--
+{"mystring":"a", "mynumber": 2.0, "mydate": {"type{date}": "2016-12-31"}}
+
+{"bytes": 1139, "count_of_rows": 1, "dataset_name": "test", "hash": "174d14a56ce3c798b369d1716488ca75"}


### PR DESCRIPTION
- `pretty-descriptor`: Specifies how datapackage descriptor (`datapackage.json`) file will look like:
    - `False` (default) - descriptor will be written in one line.
    - `True` - descriptor will have indents and new lines for each key, so it becomes more human-readable.