### PR TITLE
Add option for basic auth of web endpoints

### DIFF
--- a/datapackage_pipelines/cli.py
+++ b/datapackage_pipelines/cli.py
@@ -32,7 +32,7 @@ def cli(ctx):
 def serve():
     """Start the web server"""
     from .web import app
-    app.run(host='0.0.0.0', debug=True, port=5000)
+    app.run(host='0.0.0.0', debug=False, port=5000)
 
 
 @cli.command()

--- a/datapackage_pipelines/generators/generator_base.py
+++ b/datapackage_pipelines/generators/generator_base.py
@@ -18,7 +18,7 @@ class GeneratorBase(object):
         schema = self._get_schema()
         try:
             schema.validate(source)
-        except jsonschema.ValidationError as e:
+        except jsonschema.ValidationError:
             return False
         return True
 

--- a/datapackage_pipelines/utilities/lib_test_helpers.py
+++ b/datapackage_pipelines/utilities/lib_test_helpers.py
@@ -126,6 +126,7 @@ class ProcessorFixtureTestsBase(object):
 def rejsonize(s):
     return json.dumps(json.loads(s), sort_keys=True, ensure_ascii=True)
 
+
 def reline(data):
     data = data.strip().split('\n')
     out = ''
@@ -136,7 +137,7 @@ def reline(data):
         buf += line
         try:
             buf = json.loads(buf)
-        except:
+        except Exception:
             continue
         out += json.dumps(buf, sort_keys=True, ensure_ascii=True) + '\n'
         buf = ''

--- a/datapackage_pipelines/web/server.py
+++ b/datapackage_pipelines/web/server.py
@@ -11,8 +11,10 @@ from flask import Blueprint
 from flask import Flask, render_template, abort, redirect
 from flask_cors import CORS
 from flask_jsonpify import jsonify
+from flask_basicauth import BasicAuth
 
-from datapackage_pipelines.celery_tasks.celery_tasks import execute_update_pipelines
+from datapackage_pipelines.celery_tasks.celery_tasks import \
+    execute_update_pipelines
 from datapackage_pipelines.status import status_mgr
 from datapackage_pipelines.utilities.stat_utils import user_facing_stats
 
@@ -243,6 +245,16 @@ def badge(pipeline_id):
 
 app = Flask(__name__)
 app.config['JSONIFY_PRETTYPRINT_REGULAR'] = True
+
+if os.environ.get('DPP_BASIC_AUTH_USERNAME', False) \
+   and os.environ.get('DPP_BASIC_AUTH_PASSWORD', False):
+    app.config['BASIC_AUTH_USERNAME'] = os.environ['DPP_BASIC_AUTH_USERNAME']
+    app.config['BASIC_AUTH_PASSWORD'] = os.environ['DPP_BASIC_AUTH_PASSWORD']
+
+    basic_auth = BasicAuth(app)
+
+    app.config['BASIC_AUTH_FORCE'] = True
+
 CORS(app)
 
 url_prefix = os.environ.get('DPP_BASE_PATH', '/')

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ INSTALL_REQUIRES = [
     'awesome-slugify',
     'flask-cors',
     'flask-jsonpify',
+    'flask-basicauth',
     'cachetools',
     'tabulator>=1.14.0',
 ]


### PR DESCRIPTION
Uses [flask-basicauth](http://flask-basicauth.readthedocs.io/en/latest/) to set up basic authentication for all endpoints if the following env vars are present: 

`DPP_BASIC_AUTH_USERNAME` 
`DPP_BASIC_AUTH_PASSWORD`