### PR TITLE
support reverse order for sort processor + testing with and without leveldb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@ language: python
 python:
 - 3.6
 env:
+  matrix:
+  - TOXENV="py36-sqlite" SPEEDUP=no DEPLOY=yes
+  - TOXENV="py36-plyvel" SPEEDUP=yes DEPLOY=no
   global:
-  - TOXENV="py${PYTHON_VERSION//./}"
   - LANG=en_US.UTF-8
 install:
 - sudo apt-get install libleveldb-dev libleveldb1
-- make install-speedup
+- if [ "${SPEEDUP}" == yes ]; then make install-speedup; else make install; fi
 - pip install coveralls
 script:
 - make lint
@@ -22,5 +24,6 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
+    condition: $DEPLOY = yes
   password:
     secure: fUK/7GUs1PCMFASOxi/iWY57LfWKUivyT4r+5Gp2GaH8ytG1ux83xnSHO3e1Jrjgdak8VcV4vhwXkhU/Eno6xjHA+1G/jeIBytR9k4FKvH89gFX416/MhCxn1WMAX3AQzKqm3/gp4niI66TK/YUX526ZvCMh3EXQkC2jyctqz2A6pvleGegLNCDmRFKwgQgLNrEtDFbLwdVTqsQ+CSviEn5qFOaG8/Nh5KMYKMgCbIaJ83H1PklG7dKbFGn2aKqdvsC4uYtXbJxVkoW0D2afaM+xh1IEDz02TNzFBdAutC9qEVsbqX4TkyD6+m2x13Q8WnsCQPkEsPbZFpNDwhtUQyWr7rS+j7UxurYPTJQqZrt9AR1SSYbfgSvcmpILC+jnrxzxAa9HpleIMNLb/zgzC4ZFD75LBhWmiChPckU32/mZ7zrFveiNcMom6I+I+JPukbnhlvlOvxHQmRaQoIlkZeTmUAv7Z/Z6xz0h7WB8v/kZ+AhQq2UuXeE6tQaN//mEy5YwVKRHTexRRUnCtN2m50vaTwpvJzcQvdej8kybWtAITOA99e4vgUmoDDk/6rmzIfJP5o4ir+anTaE/kku8ay10ki3d3gr4+hk48aGoUKQFDXuWaAzf4mgu+lDPN9j3/RTIrysjwTtxMbQMAa3Kf15xoevyg2Kh0FdENgQ2u4s=

--- a/README.md
+++ b/README.md
@@ -645,12 +645,13 @@ Filtering just American and European countries, leaving out countries whose main
 Sort streamed resources by key.
 
 `sort` accepts a list of resources and a key (as a Python format string on row fields).
-It will output the rows for each resource, sorted according to the key (in ascending order).
+It will output the rows for each resource, sorted according to the key (in ascending order by default).
 
 _Parameters_:
 
 - `resources` - Which resources to sort. Same semantics as `resources` in `stream_remote_resources`.
 - `sort-by` - String, which would be interpreted as a Python format string used to form the key (e.g. `{<field_name_1>}:{field_name_2}`)
+- `reverse` - Optional boolean, if set to true - sorts in reverse order
 
 *Examples*:
 

--- a/datapackage_pipelines/lib/sort.py
+++ b/datapackage_pipelines/lib/sort.py
@@ -16,6 +16,7 @@ parameters, datapackage, resource_iterator = ingest()
 
 resources = ResourceMatcher(parameters['resources'])
 key_calc = KeyCalc(parameters['sort-by'])
+reverse = parameters.get('reverse', False)
 
 
 def sorter(resource):
@@ -23,7 +24,7 @@ def sorter(resource):
     for row_num, row in enumerate(resource):
         key = key_calc(row) + "{:08x}".format(row_num)
         db[key] = row
-    for key in db.keys():
+    for key in db.keys(reverse=reverse):
         yield db[key]
 
 

--- a/datapackage_pipelines/utilities/kvstore.py
+++ b/datapackage_pipelines/utilities/kvstore.py
@@ -42,9 +42,10 @@ class SqliteDB(object):
                                 (key, value))
         self.db.commit()
 
-    def keys(self):
+    def keys(self, reverse=False):
         cursor = self.db.cursor()
-        keys = cursor.execute('''SELECT key FROM d ORDER BY key ASC''')
+        direction = 'DESC' if reverse else 'ASC'
+        keys = cursor.execute('''SELECT key FROM d ORDER BY key ''' + direction)
         for key, in keys:
             yield key
 
@@ -73,8 +74,8 @@ class LevelDB(object):
         key = key.encode('utf8')
         self.db.put(key, value)
 
-    def keys(self):
-        for key, value in self.db:
+    def keys(self, reverse=False):
+        for key, value in self.db.iterator(reverse=reverse):
             yield key.decode('utf8')
 
     def items(self):
@@ -109,9 +110,9 @@ class CachedDB(cachetools.LRUCache):
             value = cachetools.Cache.__getitem__(self, key)
             self._dbset(key, value)
 
-    def keys(self):
+    def keys(self, reverse=False):
         self.sync()
-        return self.db.keys()
+        return self.db.keys(reverse=reverse)
 
 
 KVStore = CachedDB

--- a/tests/stdlib/fixtures/reverse_sort
+++ b/tests/stdlib/fixtures/reverse_sort
@@ -1,0 +1,109 @@
+sort
+--
+{
+    "resources": ["concat-a1", "concat-a2"],
+    "sort-by": "{a3} {a2} {a1}",
+    "reverse": true
+}
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "name": "concat-a1",
+            "dpp:streaming": true,
+            "path": "concat-a1.csv",
+            "schema": { "fields": [
+                {"name": "a1", "type": "string"},
+                {"name": "a2", "type": "string"},
+                {"name": "a3", "type": "string"}
+            ]}
+        },
+        {
+            "name": "concat-a2",
+            "dpp:streaming": true,
+            "path": "concat-a2.csv",
+            "schema": { "fields": [
+                {"name": "a1", "type": "string"},
+                {"name": "a2", "type": "string"},
+                {"name": "a3", "type": "string"}
+            ]}
+        },
+        {
+            "name": "concat-c",
+            "dpp:streaming": true,
+            "path": "concat-c.csv",
+            "schema": { "fields": [
+                {"name": "c1", "type": "string"},
+                {"name": "c2", "type": "string"},
+                {"name": "c3", "type": "string"}
+            ]}
+        }
+    ]
+}
+--
+{"a1":"a1","a2":"a1","a3":"a2"}
+{"a1":"a2","a2":"a1","a3":"a1"}
+{"a1":"a3","a2":"a2","a3":"a2"}
+{"a1":"a4","a2":"a2","a3":"a1"}
+
+{"a1":"a1","a2":"a3","a3":"a2"}
+{"a1":"a2","a2":"a3","a3":"a1"}
+{"a1":"a3","a2":"a4","a3":"a2"}
+{"a1":"a4","a2":"a4","a3":"a1"}
+
+{"c1":"c13","c2":"c23","c3":"c33"}
+{"c1":"c12","c2":"c22","c3":"c32"}
+{"c1":"c11","c2":"c21","c3":"c31"}
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "name": "concat-a1",
+            "dpp:streaming": true,
+            "path": "concat-a1.csv",
+            "schema": { "fields": [
+                {"name": "a1", "type": "string"},
+                {"name": "a2", "type": "string"},
+                {"name": "a3", "type": "string"}
+            ]}
+        },
+        {
+            "name": "concat-a2",
+            "dpp:streaming": true,
+            "path": "concat-a2.csv",
+            "schema": { "fields": [
+                {"name": "a1", "type": "string"},
+                {"name": "a2", "type": "string"},
+                {"name": "a3", "type": "string"}
+            ]}
+        },
+        {
+            "name": "concat-c",
+            "dpp:streaming": true,
+            "path": "concat-c.csv",
+            "schema": { "fields": [
+                {"name": "c1", "type": "string"},
+                {"name": "c2", "type": "string"},
+                {"name": "c3", "type": "string"}
+            ]}
+        }
+    ]
+}
+--
+{"a1":"a3","a2":"a2","a3":"a2"}
+{"a1":"a1","a2":"a1","a3":"a2"}
+{"a1":"a4","a2":"a2","a3":"a1"}
+{"a1":"a2","a2":"a1","a3":"a1"}
+
+{"a1":"a3","a2":"a4","a3":"a2"}
+{"a1":"a1","a2":"a3","a3":"a2"}
+{"a1":"a4","a2":"a4","a3":"a1"}
+{"a1":"a2","a2":"a3","a3":"a1"}
+
+{"c1":"c13","c2":"c23","c3":"c33"}
+{"c1":"c12","c2":"c22","c3":"c32"}
+{"c1":"c11","c2":"c21","c3":"c31"}
+
+{}

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 package=datapackage_pipelines
 skip_missing_interpreters=true
 envlist=
-  py36
+  py36-{sqlite,plyvel}
 
 [testenv]
 deps=
@@ -11,6 +11,7 @@ deps=
   pytest-cov
   coverage
   pyyaml
+  py36-plyvel: plyvel
 passenv=
   PWD
   CI


### PR DESCRIPTION
* support reverse order for sort - updated README, added test fixture
* modified tox and travis to support testing both with and without leveldb
