### PR TITLE
fix redis-server for alpine 3.8 + add tests for running using docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 language: python
 python:
 - 3.6
+services:
+- docker
 env:
   global:
   - TOXENV="py${PYTHON_VERSION//./}"
@@ -14,6 +16,8 @@ install:
 script:
 - make lint
 - make test
+- make build
+- tests/docker/test.sh
 after_success:
 - coveralls
 deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM python:3.6-alpine
 RUN apk --update --no-cache --virtual=build-dependencies add \
         build-base python3-dev \libxml2-dev libxslt-dev postgresql-dev  && \
     apk --update --no-cache add libstdc++ redis libpq && \
+    mkdir -p /run/redis && \
     apk --repository http://dl-3.alpinelinux.org/alpine/edge/testing/ --update add leveldb leveldb-dev && \
     pip install psycopg2 datapackage-pipelines-github datapackage-pipelines-sourcespec-registry datapackage-pipelines-aws 
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all install list lint release test version
+.PHONY: all install list lint release test version build
 
 
 PACKAGE := $(shell grep '^PACKAGE =' setup.py | cut -d "'" -f2)
@@ -29,3 +29,7 @@ test:
 
 version:
 	@echo $(VERSION)
+
+build:
+	docker pull frictionlessdata/datapackage-pipelines &&\
+	docker build -t datapackage-pipelines --cache-from frictionlessdata/datapackage-pipelines .

--- a/tests/docker/pipeline-spec.yaml
+++ b/tests/docker/pipeline-spec.yaml
@@ -1,0 +1,6 @@
+test:
+  pipeline:
+  - run: test
+  - run: dump.to_path
+    parameters:
+      out-path: data

--- a/tests/docker/test.py
+++ b/tests/docker/test.py
@@ -1,0 +1,13 @@
+from datapackage_pipelines.wrapper import ingest, spew
+from datapackage_pipelines.utilities.resources import PROP_STREAMING
+import datetime
+
+parameters, datapackage, resources, stats = ingest() + ({},)
+
+
+datapackage['resources'] = [{'name': 'test', 'path': 'test.csv',
+                             PROP_STREAMING: True,
+                             'schema': {'fields': [{'name': 'a', 'type': 'string'}]}}]
+
+
+spew(datapackage, [({'a': 'foo'}, {'a': 'bar'})], {'last_run_time': str(datetime.datetime.now())})

--- a/tests/docker/test.sh
+++ b/tests/docker/test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+sudo rm -rf tests/docker/data
+
+! docker run -v `pwd`/tests/docker:/pipelines:rw datapackage-pipelines run ./test \
+    && echo failed to run docker && exit 1
+
+! ls -lah tests/docker/data/datapackage.json tests/docker/data/test.csv \
+    && echo failed to find output files from docker run && exit 1
+
+sudo rm -rf tests/docker/data
+
+! docker run -d --name dpp -v `pwd`/tests/docker:/pipelines:rw datapackage-pipelines server \
+    && echo failed to start daemonized docker container && exit 1
+
+for i in 1 2 3 4 5 6 7 8 9; do
+    sleep 1
+    ls -lah tests/docker/data 2>/dev/null && break
+    echo .
+done
+
+docker logs dpp
+
+! ls -lah tests/docker/data/datapackage.json tests/docker/data/test.csv \
+    && echo Failed to detect outout data from daemonized docker container && exit 1
+
+docker rm --force dpp
+
+echo Great Success
+exit 0


### PR DESCRIPTION
the python image recently upgraded to alpine 3.8 (https://github.com/docker-library/python/commit/2155dc903863849059d9eb86831efa7143afa13d) - this introduces a breaking change in redis, see https://bugs.alpinelinux.org/issues/9146

this fixes the problem and also added tests of the docker image