### PR TITLE
Update datetime format string

### DIFF
--- a/datapackage_pipelines/utilities/extended_json.py
+++ b/datapackage_pipelines/utilities/extended_json.py
@@ -8,7 +8,7 @@ from .lazy_dict import LazyDict
 
 
 DATE_FORMAT = '%Y-%m-%d'
-DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S'
+DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
 TIME_FORMAT = '%H:%M:%S'
 
 


### PR DESCRIPTION
This pull request fixes [#132](https://github.com/frictionlessdata/datapackage-pipelines/issues/132).

Changes proposed in this pull request:

- Change the default datetime format string from `%Y-%m-%d %H:%M:%S` to `%Y-%m-%dT%H:%M:%SZ` in order to match [frictionless documentation](https://frictionlessdata.io/specs/table-schema/#date) 

