### PR TITLE
load_resource: fix support for loading from list of resources

### DIFF
--- a/datapackage_pipelines/lib/load_resource.py
+++ b/datapackage_pipelines/lib/load_resource.py
@@ -24,7 +24,7 @@ class ResourceLoader(object):
             assert url is not None, "Failed to fetch output datapackage for dependency '%s'" % dependency
         resource = self.parameters['resource']
         stream = self.parameters.get('stream', True)
-        name_matcher = ResourceMatcher(resource) if isinstance(resource, str) else None
+        name_matcher = ResourceMatcher(resource) if isinstance(resource, (str, list)) else None
         resource_index = resource if isinstance(resource, int) else None
 
         selected_resources = []

--- a/tests/stdlib/fixtures/simple_load_resource_list
+++ b/tests/stdlib/fixtures/simple_load_resource_list
@@ -1,0 +1,70 @@
+load_resource
+--
+{
+    "resource": ["my-spiffy-resource", "the-spiffy-resource"],
+    "url": "tests/data/datapackage2.json"
+}
+--
+{
+    "name": "test",
+    "resources": []
+}
+--
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "dpp:streamedFrom": "%(base)s/tests/data/sample.csv",
+            "name": "my-spiffy-resource",
+            "dpp:streaming": true,
+            "profile": "data-resource",
+            "path": "sample.csv",
+            "schema": {
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "last_name", "type": "string"},
+                    {"name": "house", "type": "string"},
+                    {"name": "age", "type": "integer"}
+                ]
+            }
+        },
+        {
+            "dpp:streamedFrom": "%(base)s/tests/data/sample.csv",
+            "name": "the-spiffy-resource",
+            "dpp:streaming": true,
+            "profile": "data-resource",
+            "path": "sample.csv",
+            "schema": {
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "last_name", "type": "string"},
+                    {"name": "house", "type": "string"},
+                    {"name": "age", "type": "integer"}
+                ]
+            }
+        }
+    ]
+}
+--
+{"first_name": "Tyrion", "house": "Lannister", "last_name": "Lannister", "age": 27}
+{"first_name": "Jaime", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Cersei", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Jon", "house": "Stark", "last_name": "Snow", "age": 17}
+{"first_name": "Sansa", "house": "Stark", "last_name": "Stark", "age": 14}
+{"first_name": "Arya", "house": "Stark", "last_name": "Stark", "age": 11}
+{"first_name": "Bran", "house": "Stark", "last_name": "Stark", "age": 10}
+{"first_name": "Rickon", "house": "Stark", "last_name": "Stark", "age": 5}
+{"first_name": "Daenerys", "house": "Targaryen", "last_name": "Targaryen", "age": 16}
+
+{"first_name": "Tyrion", "house": "Lannister", "last_name": "Lannister", "age": 27}
+{"first_name": "Jaime", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Cersei", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Jon", "house": "Stark", "last_name": "Snow", "age": 17}
+{"first_name": "Sansa", "house": "Stark", "last_name": "Stark", "age": 14}
+{"first_name": "Arya", "house": "Stark", "last_name": "Stark", "age": 11}
+{"first_name": "Bran", "house": "Stark", "last_name": "Stark", "age": 10}
+{"first_name": "Rickon", "house": "Stark", "last_name": "Stark", "age": 5}
+{"first_name": "Daenerys", "house": "Targaryen", "last_name": "Targaryen", "age": 16}
+
+{}


### PR DESCRIPTION
fixed a small bug in load_resource which prevented `resource` attribute from accepting a `list` of resources

added corresponding test