### PR TITLE
Load resource: support modifying metadata on load and skipping resource loading errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,12 @@ All properties of the loaded resource will be copied - `path` and `schema` inclu
 
 - `stream` - if provided and is set to false, then the resource will be added to the datapackage but not streamed.
 
+- `resources` - can be used instead of `resource` property to support loading resources and modify the output resource metadata
+    - Value is a dict containing mapping between source resource name to load and dict containing descriptor updates to apply to the loaded resource
+
+- `required` - if provided and set to false, will not fail if datapackage is not available or resource is missing
+
+
 *Example*:
 
 ```yaml
@@ -396,6 +402,13 @@ All properties of the loaded resource will be copied - `path` and `schema` inclu
   parameters:
     url: http://example.com/my-other-datapackage/datapackage.json
     resource: 1
+- run: load_resource
+  parameters:
+    url: http://example.com/my-datapackage/datapackage.json
+    resources:
+      my-resource:
+        name: my-renamed-resource
+        path: my-renamed-resource.csv
 ```
 
 

--- a/datapackage_pipelines/lib/load_resource.py
+++ b/datapackage_pipelines/lib/load_resource.py
@@ -22,36 +22,53 @@ class ResourceLoader(object):
             dependency = url[len(dep_prefix):].strip()
             url = get_dependency_datapackage_url(dependency)
             assert url is not None, "Failed to fetch output datapackage for dependency '%s'" % dependency
-        resource = self.parameters['resource']
         stream = self.parameters.get('stream', True)
+        required = self.parameters.get('required', True)
+        resource = self.parameters.get('resource')
+        resources = self.parameters.get('resources')
+        if resource is not None:
+            assert not resources
+            resource_index = resource if isinstance(resource, int) else None
+        else:
+            assert resources
+            resource_index = None
+            resource = list(resources.keys())
         name_matcher = ResourceMatcher(resource) if isinstance(resource, (str, list)) else None
-        resource_index = resource if isinstance(resource, int) else None
 
         selected_resources = []
         found = False
-        dp = datapackage.DataPackage(url)
-        dp = self.process_datapackage(dp)
-        for i, orig_res in enumerate(dp.resources):
-            if resource_index == i or \
-                    (name_matcher is not None and name_matcher.match(orig_res.descriptor.get('name'))):
-                found = True
-                desc = copy.deepcopy(orig_res.descriptor)
-                if 'primaryKey' in desc.get('schema', {}):
-                    # Avoid duplication checks
-                    del orig_res.descriptor['schema']['primaryKey']
-                    orig_res.commit()
-                desc[PROP_STREAMED_FROM] = orig_res.source
-                self.dp['resources'].append(desc)
-                if tabular(desc) and stream:
-                    desc[PROP_STREAMING] = True
-                    orig_res_iter = orig_res.iter(keyed=True)
-                    if limit_rows:
-                        orig_res_iter = itertools.islice(orig_res_iter, limit_rows)
-                    selected_resources.append(orig_res_iter)
-                else:
-                    desc[PROP_STREAMING] = False
+        try:
+            dp = datapackage.DataPackage(url)
+        except Exception:
+            if required:
+                raise
+            else:
+                dp = None
+        if dp:
+            dp = self.process_datapackage(dp)
+            for i, orig_res in enumerate(dp.resources):
+                if resource_index == i or \
+                        (name_matcher is not None and name_matcher.match(orig_res.descriptor.get('name'))):
+                    found = True
+                    desc = copy.deepcopy(orig_res.descriptor)
+                    if 'primaryKey' in desc.get('schema', {}):
+                        # Avoid duplication checks
+                        del orig_res.descriptor['schema']['primaryKey']
+                        orig_res.commit()
+                    desc[PROP_STREAMED_FROM] = orig_res.source
+                    if resources:
+                        desc.update(resources[desc['name']])
+                    self.dp['resources'].append(desc)
+                    if tabular(desc) and stream:
+                        desc[PROP_STREAMING] = True
+                        orig_res_iter = orig_res.iter(keyed=True)
+                        if limit_rows:
+                            orig_res_iter = itertools.islice(orig_res_iter, limit_rows)
+                        selected_resources.append(orig_res_iter)
+                    else:
+                        desc[PROP_STREAMING] = False
 
-        assert found, "Failed to find resource with index or name matching %r" % resource
+        assert found or not required, "Failed to find resource with index or name matching %r" % resource
         spew(self.dp, itertools.chain(self.res_iter, selected_resources))
 
     def process_datapackage(self, dp_):

--- a/datapackage_pipelines/lib/load_resource.py
+++ b/datapackage_pipelines/lib/load_resource.py
@@ -24,7 +24,7 @@ class ResourceLoader(object):
             assert url is not None, "Failed to fetch output datapackage for dependency '%s'" % dependency
         resource = self.parameters['resource']
         stream = self.parameters.get('stream', True)
-        name_matcher = ResourceMatcher(resource) if isinstance(resource, str) else None
+        name_matcher = ResourceMatcher(resource) if isinstance(resource, (str, list)) else None
         resource_index = resource if isinstance(resource, int) else None
 
         selected_resources = []

--- a/tests/stdlib/fixtures/simple_load_resource_list
+++ b/tests/stdlib/fixtures/simple_load_resource_list
@@ -1,0 +1,70 @@
+load_resource
+--
+{
+    "resource": ["my-spiffy-resource", "the-spiffy-resource"],
+    "url": "tests/data/datapackage2.json"
+}
+--
+{
+    "name": "test",
+    "resources": []
+}
+--
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "dpp:streamedFrom": "%(base)s/tests/data/sample.csv",
+            "name": "my-spiffy-resource",
+            "dpp:streaming": true,
+            "profile": "data-resource",
+            "path": "sample.csv",
+            "schema": {
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "last_name", "type": "string"},
+                    {"name": "house", "type": "string"},
+                    {"name": "age", "type": "integer"}
+                ]
+            }
+        },
+        {
+            "dpp:streamedFrom": "%(base)s/tests/data/sample.csv",
+            "name": "the-spiffy-resource",
+            "dpp:streaming": true,
+            "profile": "data-resource",
+            "path": "sample.csv",
+            "schema": {
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "last_name", "type": "string"},
+                    {"name": "house", "type": "string"},
+                    {"name": "age", "type": "integer"}
+                ]
+            }
+        }
+    ]
+}
+--
+{"first_name": "Tyrion", "house": "Lannister", "last_name": "Lannister", "age": 27}
+{"first_name": "Jaime", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Cersei", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Jon", "house": "Stark", "last_name": "Snow", "age": 17}
+{"first_name": "Sansa", "house": "Stark", "last_name": "Stark", "age": 14}
+{"first_name": "Arya", "house": "Stark", "last_name": "Stark", "age": 11}
+{"first_name": "Bran", "house": "Stark", "last_name": "Stark", "age": 10}
+{"first_name": "Rickon", "house": "Stark", "last_name": "Stark", "age": 5}
+{"first_name": "Daenerys", "house": "Targaryen", "last_name": "Targaryen", "age": 16}
+
+{"first_name": "Tyrion", "house": "Lannister", "last_name": "Lannister", "age": 27}
+{"first_name": "Jaime", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Cersei", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Jon", "house": "Stark", "last_name": "Snow", "age": 17}
+{"first_name": "Sansa", "house": "Stark", "last_name": "Stark", "age": 14}
+{"first_name": "Arya", "house": "Stark", "last_name": "Stark", "age": 11}
+{"first_name": "Bran", "house": "Stark", "last_name": "Stark", "age": 10}
+{"first_name": "Rickon", "house": "Stark", "last_name": "Stark", "age": 5}
+{"first_name": "Daenerys", "house": "Targaryen", "last_name": "Targaryen", "age": 16}
+
+{}

--- a/tests/stdlib/fixtures/simple_load_resource_required
+++ b/tests/stdlib/fixtures/simple_load_resource_required
@@ -1,0 +1,20 @@
+load_resource
+--
+{
+    "resource": "foobar",
+    "url": "foo/bar/datapackage.json",
+    "required": false
+}
+--
+{
+    "name": "test",
+    "resources": []
+}
+--
+--
+{
+    "name": "test",
+    "resources": []
+}
+--
+{}

--- a/tests/stdlib/fixtures/simple_load_resource_resources
+++ b/tests/stdlib/fixtures/simple_load_resource_resources
@@ -1,0 +1,76 @@
+load_resource
+--
+{
+    "resources": {
+        "my-spiffy-resource": {},
+        "the-spiffy-resource": {
+            "name": "renamed-spiffy-resource",
+            "path": "renamed-spiffy-resource.csv"
+        }
+    },
+    "url": "tests/data/datapackage2.json"
+}
+--
+{
+    "name": "test",
+    "resources": []
+}
+--
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "dpp:streamedFrom": "%(base)s/tests/data/sample.csv",
+            "name": "my-spiffy-resource",
+            "dpp:streaming": true,
+            "profile": "data-resource",
+            "path": "sample.csv",
+            "schema": {
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "last_name", "type": "string"},
+                    {"name": "house", "type": "string"},
+                    {"name": "age", "type": "integer"}
+                ]
+            }
+        },
+        {
+            "dpp:streamedFrom": "%(base)s/tests/data/sample.csv",
+            "name": "renamed-spiffy-resource",
+            "dpp:streaming": true,
+            "profile": "data-resource",
+            "path": "renamed-spiffy-resource.csv",
+            "schema": {
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "last_name", "type": "string"},
+                    {"name": "house", "type": "string"},
+                    {"name": "age", "type": "integer"}
+                ]
+            }
+        }
+    ]
+}
+--
+{"first_name": "Tyrion", "house": "Lannister", "last_name": "Lannister", "age": 27}
+{"first_name": "Jaime", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Cersei", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Jon", "house": "Stark", "last_name": "Snow", "age": 17}
+{"first_name": "Sansa", "house": "Stark", "last_name": "Stark", "age": 14}
+{"first_name": "Arya", "house": "Stark", "last_name": "Stark", "age": 11}
+{"first_name": "Bran", "house": "Stark", "last_name": "Stark", "age": 10}
+{"first_name": "Rickon", "house": "Stark", "last_name": "Stark", "age": 5}
+{"first_name": "Daenerys", "house": "Targaryen", "last_name": "Targaryen", "age": 16}
+
+{"first_name": "Tyrion", "house": "Lannister", "last_name": "Lannister", "age": 27}
+{"first_name": "Jaime", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Cersei", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Jon", "house": "Stark", "last_name": "Snow", "age": 17}
+{"first_name": "Sansa", "house": "Stark", "last_name": "Stark", "age": 14}
+{"first_name": "Arya", "house": "Stark", "last_name": "Stark", "age": 11}
+{"first_name": "Bran", "house": "Stark", "last_name": "Stark", "age": 10}
+{"first_name": "Rickon", "house": "Stark", "last_name": "Stark", "age": 5}
+{"first_name": "Daenerys", "house": "Targaryen", "last_name": "Targaryen", "age": 16}
+
+{}

--- a/tests/stdlib/fixtures/simple_load_resource_resources_required
+++ b/tests/stdlib/fixtures/simple_load_resource_resources_required
@@ -1,0 +1,52 @@
+load_resource
+--
+{
+    "resources": {
+        "my-spiffy-resource": {},
+        "nonexistent-spiffy-resource": {
+            "name": "renamed-spiffy-resource",
+            "path": "renamed-spiffy-resource.csv"
+        }
+    },
+    "url": "tests/data/datapackage2.json",
+    "required": false
+}
+--
+{
+    "name": "test",
+    "resources": []
+}
+--
+--
+{
+    "name": "test",
+    "resources": [
+        {
+            "dpp:streamedFrom": "%(base)s/tests/data/sample.csv",
+            "name": "my-spiffy-resource",
+            "dpp:streaming": true,
+            "profile": "data-resource",
+            "path": "sample.csv",
+            "schema": {
+                "fields": [
+                    {"name": "first_name", "type": "string"},
+                    {"name": "last_name", "type": "string"},
+                    {"name": "house", "type": "string"},
+                    {"name": "age", "type": "integer"}
+                ]
+            }
+        }
+    ]
+}
+--
+{"first_name": "Tyrion", "house": "Lannister", "last_name": "Lannister", "age": 27}
+{"first_name": "Jaime", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Cersei", "house": "Lannister", "last_name": "Lannister", "age": 34}
+{"first_name": "Jon", "house": "Stark", "last_name": "Snow", "age": 17}
+{"first_name": "Sansa", "house": "Stark", "last_name": "Stark", "age": 14}
+{"first_name": "Arya", "house": "Stark", "last_name": "Stark", "age": 11}
+{"first_name": "Bran", "house": "Stark", "last_name": "Stark", "age": 10}
+{"first_name": "Rickon", "house": "Stark", "last_name": "Stark", "age": 5}
+{"first_name": "Daenerys", "house": "Targaryen", "last_name": "Targaryen", "age": 16}
+
+{}


### PR DESCRIPTION
additional features for load resource:

1. support modifying resource metadata on load - to support easy renaming of resources or saving to a different path
2. optionally skip invalid datapackage or mismatched resource names - to support common use case of incremental update - on first run the same resource doesn't exist, causing full update, and on next run it will load and update incrementally.

updated README and added fixtures

PR depends on bug fix from PR #139 