### PR TITLE
Filter dashboard by pipeline collection

### DIFF
--- a/datapackage_pipelines/web/server.py
+++ b/datapackage_pipelines/web/server.py
@@ -86,10 +86,19 @@ blueprint = Blueprint('dpp', 'dpp')
 
 
 @blueprint.route("")
-def main():
-    all_pipeline_ids = sorted(status.all_pipeline_ids())
+@blueprint.route("<path:pipeline_path>")
+def main(pipeline_path=None):
+    pipeline_ids = sorted(status.all_pipeline_ids())
+
+    # If we have a pipeline_path, filter the pipeline ids.
+    if pipeline_path is not None:
+        if not pipeline_path.startswith('./'):
+            pipeline_path = './' + pipeline_path
+
+        pipeline_ids = [p for p in pipeline_ids if p.startswith(pipeline_path)]
+
     statuses = []
-    for pipeline_id in all_pipeline_ids:
+    for pipeline_id in pipeline_ids:
         pipeline_status = status.get(pipeline_id)
         ex = pipeline_status.get_last_execution()
         success_ex = pipeline_status.get_last_successful_execution()
@@ -114,7 +123,8 @@ def main():
                       }[pipeline_status.state()],
             'ended': datestr(ex.finish_time) if ex else None,
             'started': datestr(ex.start_time) if ex else None,
-            'last_success': datestr(success_ex.finish_time) if success_ex else None,
+            'last_success':
+                datestr(success_ex.finish_time) if success_ex else None,
         }
         statuses.append(pipeline_obj)
 

--- a/datapackage_pipelines/web/templates/dashboard.html
+++ b/datapackage_pipelines/web/templates/dashboard.html
@@ -100,7 +100,7 @@
     <div class="container-fluid">
         <!-- Brand and toggle get grouped for better mobile display -->
         <div class="navbar-header">
-            <a class="navbar-brand" href="#">Pipeline Status Dashboard</a>
+            <a class="navbar-brand" href="{{ url_for('dpp.main') }}">Pipeline Status Dashboard</a>
         </div>
 
         <!-- Collect the nav links, forms, and other content for toggling -->

--- a/datapackage_pipelines/web/templates/dashboard.html
+++ b/datapackage_pipelines/web/templates/dashboard.html
@@ -121,17 +121,22 @@
             <div class="row">
                 <div class="col-md-3 hidden-xs hidden-sm">
                     <div data-spy="affix" >
-                        {% macro nested_pipelines(statuses) %}
+                        {% macro nested_pipelines(statuses, parent='') %}
                         {% for k, children in statuses.children.items() %}
                         <div class="row">
                             <div class="col-xs-12">
                                 <div class="nesting open">
                                     <div class="nesting-title">
                                         <span class="glyphicon glyphicon-menu-right"></span>
-                                        <span>{{ k }}</span>
+                                        {% if parent %}
+                                          {% set pipeline_path = parent + '/' + k %}
+                                        {% else %}
+                                          {% set pipeline_path = k %}
+                                        {% endif %}
+                                        <span><a href="{{ url_for('dpp.main', pipeline_path=pipeline_path) }}">{{ k }}</a></span>
                                     </div>
                                     <div class="nesting-contents">
-                                        {{ nested_pipelines(children) }}
+                                        {{ nested_pipelines(children, k) }}
                                     </div>
                                 </div>
                             </div>
@@ -283,14 +288,15 @@
       var field = target.attr('data-field');
       if (!field) return;
       var pipeline_id = target.attr('data-pipeline');
-      $.get('api/'+field+'/'+pipeline_id, function(data) {
-        text = data.text;
-        contents = '<pre>';
-        for (i = 0 ; i < text.length ; i++) contents += text[i] + '\n';
-        contents = contents + '</pre>';
-        target.html(contents);
-        target.attr('data-full', true);
-      }, 'json');
+      $.get("{{ url_for('dpp.main') }}" + "api/" + field + "/" + pipeline_id,
+        function(data) {
+          text = data.text;
+          contents = '<pre>';
+          for (i = 0 ; i < text.length ; i++) contents += text[i] + '\n';
+          contents = contents + '</pre>';
+          target.html(contents);
+          target.attr('data-full', true);
+        }, 'json');
     }
 
     $('[role=tabpanel]').on('shown.bs.tab', function(e) {


### PR DESCRIPTION
This PR expands the `main` view function of the pipeline dashboard to allow finer control of the displayed pipelines. Instead of displaying all pipelines, a pipeline path can be appended to the root url to filter the displayed pipelines. E.g. http://localhost:5000/europe/croatia will filter the pipeline ids to only include those that start with `./europe/croatia`. This provides a quick method to have collection based views for the dashboard.

The nested sidebar nav titles are also linked appropriately to provide a way to get to these collection filtered views, and the home link is fixed to provide a quick way back to the complete dashboard.