### PR TITLE
Update function call of add_computed_field

### DIFF
--- a/datapackage_pipelines/lib/add_computed_field.py
+++ b/datapackage_pipelines/lib/add_computed_field.py
@@ -7,7 +7,7 @@ def flow(parameters):
     return Flow(
         add_computed_field(
             parameters.get('fields', []),
-            parameters.get('resources')
+            resources=parameters.get('resources')
         ),
     )
 


### PR DESCRIPTION
The add_computed_field function in data flow (https://github.com/datahq/dataflows/blob/master/dataflows/processors/add_computed_field.py#L73) looks like this:
```
def add_computed_field(*args, resources=None, **kw):
```

but the add_computed_field processor in datapackage_pipelines calls it like this:
```
def flow(parameters):
    return Flow(
        add_computed_field(
            parameters.get('fields', []),
            parameters.get('resources')
        ),
)
```

This PR correctly calls the add_computed_field flow using resource as a named parameter. Without this PR the add_computed_field processor does not work.

The function signature in dataflows was updated sometime between 0.0.44 and 0.0.48 but the function in datapackage_pipelines was not updated.