### PR TITLE
Make streamed_from follow the source

### DIFF
--- a/datapackage_pipelines/lib/load.py
+++ b/datapackage_pipelines/lib/load.py
@@ -20,8 +20,8 @@ def flow(parameters):
     def mark_streaming(_from):
         def func(package):
             for i in range(num_resources, len(package.pkg.resources)):
-                package.pkg.descriptor['resources'][i][PROP_STREAMING] = True
-                package.pkg.descriptor['resources'][i][PROP_STREAMED_FROM] = _from
+                package.pkg.descriptor['resources'][i].setdefault(PROP_STREAMING, True)
+                package.pkg.descriptor['resources'][i].setdefault(PROP_STREAMED_FROM,  _from)
             yield package.pkg
             yield from package
         return func


### PR DESCRIPTION
Hey @akariv, here is an issue https://github.com/BCODMO/frictionless-usecases/issues/10 and I'm not sure whether it's a bug in DPP or an incorrect issue. It should be one of those:

- issue is incorrect and it's how the `streamed_from` has to behave
- issue is partially incorrect and it's how the `streamed_from` has to behave BUT it has to be removed on the dump step as it happens to `streaming` prop
- issue is correct and this PR fixes it