### PR TITLE
fix bug with html escape in dashboard, fix werkzeug dependency

### DIFF
--- a/datapackage_pipelines/web/templates/dashboard.html
+++ b/datapackage_pipelines/web/templates/dashboard.html
@@ -291,10 +291,11 @@
       $.get("{{ url_for('dpp.main') }}" + "api/" + field + "/" + pipeline_id,
         function(data) {
           text = data.text;
-          contents = '<pre>';
+          contents = '';
           for (i = 0 ; i < text.length ; i++) contents += text[i] + '\n';
-          contents = contents + '</pre>';
-          target.html(contents);
+          contentsPre = $('<pre>');
+          contentsPre.text(contents);
+          target.html('').append(contentsPre);
           target.attr('data-full', true);
         }, 'json');
     }

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ INSTALL_REQUIRES = [
     'globster>=0.1.0',
     'dataflows>=0.0.65',
     'python-dateutil<2.8.1',
+    'werkzeug<1.0'
 ]
 SPEEDUP_REQUIRES = [
     'dataflows[speedup]',

--- a/tests/serve/html_output.py
+++ b/tests/serve/html_output.py
@@ -1,0 +1,11 @@
+from dataflows import Flow
+import logging
+
+
+class MyClass():
+    pass
+
+
+def flow(*_):
+    logging.info('my_object=' + str(MyClass()))
+    return Flow()

--- a/tests/serve/pipeline-spec.yaml
+++ b/tests/serve/pipeline-spec.yaml
@@ -1,0 +1,3 @@
+html-output:
+  pipeline:
+    - flow: html_output


### PR DESCRIPTION
includes 2 fixes:

## bug with html escape in dashboard

* `dpp run --verbose tests/serve/html-output` (included in the PR)
* see the log including html special chars: `my_object=<html_output.MyClass object at 0x7f2351222128>`
* `dpp serve`
* read the log in the dashboard
* **expected**: show the log
* **actual**: the output following my_object= does not appear

## werkzeug dependency

* `dpp serve`
* read a pipeline log
* **expected**: log appears
* **actual**: http 500 error in the get log request
* this is due to change in werkzueg (Flask dependency) which is introduced in latest version, setting to version lower then 1.0 fixes it
