### PR TITLE
Add redis user and password support

### DIFF
--- a/datapackage_pipelines/celery_tasks/dependency_manager.py
+++ b/datapackage_pipelines/celery_tasks/dependency_manager.py
@@ -9,7 +9,14 @@ class DependencyManager(object):
     def __init__(self, host=os.environ.get('DPP_REDIS_HOST'), port=6379):
         self.redis = None
         if host is not None and len(host) > 0:
-            conn = redis.StrictRedis(host=host, port=port, db=5)
+            params = {
+                'host': host, 
+                'port': port, 
+                'db': 5,
+                'username': os.environ.get('DPP_REDIS_USERNAME'),
+                'password': os.environ.get('DPP_REDIS_PASSWORD'),
+            }
+            conn = redis.StrictRedis(**params)
             try:
                 conn.ping()
                 self.redis = conn

--- a/datapackage_pipelines/celery_tasks/dependency_manager.py
+++ b/datapackage_pipelines/celery_tasks/dependency_manager.py
@@ -10,8 +10,8 @@ class DependencyManager(object):
         self.redis = None
         if host is not None and len(host) > 0:
             params = {
-                'host': host, 
-                'port': port, 
+                'host': host,
+                'port': port,
                 'db': 5,
                 'username': os.environ.get('DPP_REDIS_USERNAME'),
                 'password': os.environ.get('DPP_REDIS_PASSWORD'),

--- a/datapackage_pipelines/status/backend_redis.py
+++ b/datapackage_pipelines/status/backend_redis.py
@@ -12,7 +12,7 @@ class RedisBackend(object):
     def __init__(self, host=None, port=6379, username=None, password=None):
         self.redis = None
         if host is not None and len(host) > 0:
-            conn = redis.StrictRedis(host=host, port=port, db=5, 
+            conn = redis.StrictRedis(host=host, port=port, db=5,
                                      username=username, password=password)
             try:
                 conn.ping()

--- a/datapackage_pipelines/status/backend_redis.py
+++ b/datapackage_pipelines/status/backend_redis.py
@@ -9,10 +9,11 @@ class RedisBackend(object):
 
     KIND = 'redis'
 
-    def __init__(self, host=None, port=6379):
+    def __init__(self, host=None, port=6379, username=None, password=None):
         self.redis = None
         if host is not None and len(host) > 0:
-            conn = redis.StrictRedis(host=host, port=port, db=5)
+            conn = redis.StrictRedis(host=host, port=port, db=5, 
+                                     username=username, password=password)
             try:
                 conn.ping()
                 self.redis = conn

--- a/datapackage_pipelines/status/status_manager.py
+++ b/datapackage_pipelines/status/status_manager.py
@@ -8,15 +8,17 @@ from .pipeline_status import PipelineStatus
 class StatusManager(object):
 
     def __init__(self, *, host=None, port=6379, root_dir='.'):
-        self._host = host
+        self._host = os.environ.get('DPP_REDIS_HOST')
         self._port = port
+        self._username = os.environ.get('DPP_REDIS_USERNAME')
+        self._password = os.environ.get('DPP_REDIS_PASSWORD')
         self._backend = None
         self._root_dir = root_dir
 
     @property
     def backend(self):
         if self._backend is None:
-            redis = RedisBackend(self._host, self._port)
+            redis = RedisBackend(self._host, self._port, self._username, self._password)
             self._backend = redis if redis.is_init() else FilesystemBackend(self._root_dir)
         return self._backend
 
@@ -53,5 +55,5 @@ def status_mgr(root_dir='.') -> StatusManager:
     if _status is not None and _root_dir == root_dir:
         return _status
     _root_dir = root_dir
-    _status = StatusManager(host=os.environ.get('DPP_REDIS_HOST'), root_dir=root_dir)
+    _status = StatusManager(root_dir=root_dir)
     return _status


### PR DESCRIPTION
* [ ] I've added tests to cover the proposed changes

Changes proposed in this pull request:

- add support for Redis authentification through `DPP_REDIS_USERNAME` and `DPP_REDIS_PASSWORD` env vars

Replaces #199  