### PR TITLE
Fix missing comma in tar_args tuple for File.compress_to

### DIFF
--- a/datapackage_pipelines/utilities/dirtools.py
+++ b/datapackage_pipelines/utilities/dirtools.py
@@ -94,7 +94,7 @@ class File(object):
             tar_kwargs = {'fileobj': archive}
             _return = archive.name
         else:
-            tar_args = (archive_path)
+            tar_args = (archive_path,)
             tar_kwargs = {}
             _return = archive_path
         tar_kwargs.update({'mode': 'w:gz'})


### PR DESCRIPTION
## Summary
Fixes a missing comma in the tuple literal for `tar_args` inside `File.compress_to` when an `archive_path` is provided.

This bug caused `tarfile.open()` to receive the archive path as individual string characters instead of a single positional argument, resulting in a `TypeError`.

## Verification
- Reproduced the failure locally with a minimal script before the change.
- Confirmed `compress_to` succeeds after the fix.

## Files changed
- `datapackage_pipelines/utilities/dirtools.py` (1 line changed)
